### PR TITLE
Dynamically set dependent keys for _value on init.

### DIFF
--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -61,6 +61,20 @@ export default Ember.Component.extend({
     this._super(...arguments);
     Ember.assert('Must use table column as a child of table-columns or fixed-table-columns.', this.parentView);
     run.scheduleOnce('actions', this, this._registerWithParent);
+
+    this._setValueDependentKeys();
+  },
+
+  /**
+    Sets dependent keys on the _value computed property. This is done since
+    we need to clear the cached version based on a dynamic key, and volatile()
+    does not do the needful.
+    @private
+  **/
+  _setValueDependentKeys() {
+    const path = this.get('valueBindingPath');
+    const pathKey = `row.${path}`;
+    this._value.property('valueBindingPath', 'row', pathKey);
   },
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.1.3",
     "ember-load-initializers": "#0.1.7",
-    "ember-qunit": "0.4.9",
+    "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "Faker": "~3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.0",
+    "ember-cli-qunit": "^1.0.4",
     "ember-cli-release": "0.2.3",
     "ember-cli-showdown": "2.5.0",
     "ember-cli-sri": "^1.0.3",
@@ -42,8 +42,8 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-faker": "1.1.0",
-    "ember-suave": "1.2.2",
-    "ember-try": "0.0.6"
+    "ember-suave": "1.2.3",
+    "ember-try": "0.0.8"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Otherwise updates to the other cells will not trigger.

Use case: create a new manual row, and then save the object.
