### PR TITLE
Fixed column fixes, add textWrap, collapsable fixes

### DIFF
--- a/addon/components/basic-header.js
+++ b/addon/components/basic-header.js
@@ -6,15 +6,17 @@ const { computed } = Ember;
 export default Ember.Component.extend({
   layout,
   tagName: 'th',
-  classNameBindings: ['alignCenter:center', 'alignRight:right'],
+  classNameBindings: ['alignCenter:center', 'alignRight:right', 'textWrap'],
   alignCenter: computed.equal('column.align', 'center'),
   alignRight: computed.equal('column.align', 'right'),
+  textWrap: computed.equal('column.textWrap', true),
 
   column: null,
   resizable: computed.readOnly('column.resizable'),
 
   didRender() {
     this._setColumnWidth();
+    this.getAttr('table').ensureEqualHeaderHeight();
   },
 
   _setColumnWidth() {

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/justa-table';
 
 const { empty } = Ember.computed;
+const { run, isEmpty } = Ember;
 
 export default Ember.Component.extend({
   layout,
@@ -18,6 +19,32 @@ export default Ember.Component.extend({
     @public
   */
   noContent: empty('content'),
+
+  /**
+    Ensure header heights are equal. Schedules after render to ensure it's
+    called once per table.
+    @public
+  */
+  ensureEqualHeaderHeight() {
+    run.scheduleOnce('afterRender', this, this._ensureEqualHeaderHeight);
+  },
+
+  /**
+    If we have any fixed columns, make sure the fixed columns and standard
+    table column header heights stay in sync.
+    @private
+  */
+  _ensureEqualHeaderHeight() {
+    let fixedHeader = this.$('.fixed-table-columns th:first-of-type');
+    if (isEmpty(fixedHeader)) {
+      return;
+    }
+    let columnHeader = this.$('.table-columns th:first-of-type');
+    let maxHeight = Math.max(fixedHeader.height(), columnHeader.height());
+
+    fixedHeader.height(maxHeight);
+    columnHeader.height(maxHeight);
+  },
 
   actions: {
     /**

--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
   /**
     The header component this column should use to render its header.
     @public
+    @default 'basic-header'
   */
   headerComponent: 'basic-header',
 
@@ -36,12 +37,14 @@ export default Ember.Component.extend({
   /**
     If the table column is resizable.
     @public
+    @default false
   */
   resizable: false,
 
   /**
     If a fake rowspan class should be added when the cell value is empty.
     @public
+    @default false
   */
   useFakeRowspan: false,
 

--- a/addon/styles/_justa-table.scss
+++ b/addon/styles/_justa-table.scss
@@ -14,7 +14,7 @@
     height: 36px;
   }
 
-  tr:hover {
+  tr:hover, tr.hover {
     background: #e9f7f7;
   }
 
@@ -32,6 +32,10 @@
     &.right {
       text-align: right;
     }
+  }
+
+  th.text-wrap {
+    white-space: normal;
   }
 
   table {

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -1,29 +1,11 @@
 <table class="table">
-  {{!--
-    define colgroups here. example for 2 grouped header columns
-    <colgroup span="2"></colgroup>
-    <colgroup span="2"></colgroup>
-  --}}
   <thead>
-    {{!--
-      For grouped:
-      <tr>
-        <th colspan="2" scope="colgroup">Mars</th>
-        <th colspan="2" scope="colgroup">Venus</th>
-      </tr>
-
-      <tr>
-        <th scope="col">Produced</th>
-        <th scope="col">Sold</th>
-        <th scope="col">Produced</th>
-        <th scope="col">Sold</th>
-      </tr>
-
-      http://www.w3.org/WAI/tutorials/tables/irregular/
-    --}}
     <tr>
       {{#each columns as |column|}}
-        {{component column.headerComponent column=column onColumnWidthChange=(action 'columnWidthChanged')}}
+        {{component column.headerComponent
+          table=table
+          column=column
+          onColumnWidthChange=(action 'columnWidthChanged')}}
       {{/each}}
     </tr>
   </thead>
@@ -32,26 +14,25 @@
     {{! TODO: render diff template instead of this if }}
     {{#if table.collapsable}}
       {{#each table.content as |rowGroup|}}
-        <tr class="{{mergedRowClasses}} collapsable {{if rowGroup.isCollapsed 'is-collapsed'}}" {{action 'toggleRowCollapse' rowGroup}}>
-          <td colspan={{columns.length}} class="table-cell">
-            {{rowGroup.label}}
-          </td>
+        <tr class="table-row {{mergedRowClasses}} collapsable {{if (eq rowGroup.isCollapsed false) 'is-expanded' 'is-collapsed'}} {{if rowGroup.loading 'is-loading'}}" {{action 'toggleRowCollapse' rowGroup}}>
+
+          {{#if rowGroup.label}}
+            <td colspan={{columns.length}} class="table-cell">
+              {{rowGroup.label}}
+            </td>
+          {{else}}
+            {{yield rowGroup}}
+          {{/if}}
         </tr>
-        {{#if rowGroup.loading}}
-          <tr>
-            <td colspan={{columns.length}} class="table-cell">LOADIN!</td>
+        {{#each rowGroup.data as |childRow|}}
+          <tr class="{{if rowGroup.isCollapsed 'is-collapsed'}}">
+            {{yield childRow}}
           </tr>
         {{else}}
-          {{#each rowGroup.data as |childRow|}}
-            <tr class="{{if rowGroup.isCollapsed 'is-collapsed'}}">
-              {{yield childRow}}
-            </tr>
-          {{else}}
-            <tr class="is-collapsed">
-              {{yield}}
-            </tr>
-          {{/each}}
-        {{/if}}
+          <tr class="is-collapsed">
+            {{yield}}
+          </tr>
+        {{/each}}
       {{/each}}
     {{else}}
       {{#each table.content as |row|}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    babel: {
+      includePolyfill: true
+    }
   });
 
   /*

--- a/tests/dummy/app/pods/examples/fixed-column-table/template.hbs
+++ b/tests/dummy/app/pods/examples/fixed-column-table/template.hbs
@@ -57,3 +57,26 @@
     {{/table-column}}
   {{/table-columns}}
 {{/justa-table}}
+
+<p>Allow text wrapping for column headers with textWrap=true</p>
+
+{{#justa-table content=model as |table|}}
+  {{#fixed-table-columns table=table as |row|}}
+    {{table-column
+      row=row
+      width=150
+      textWrap=true
+      headerName='This is a super long header name'
+      valueBindingPath='displayName'}}
+
+  {{/fixed-table-columns}}
+
+  {{#table-columns table=table as |row|}}
+
+    {{table-column
+      row=row
+      width=550
+      headerName='Address'
+      valueBindingPath='address'}}
+  {{/table-columns}}
+{{/justa-table}}


### PR DESCRIPTION
- Add textWrap option to columns
- Ensure headers are equal height when using fixed tables
- Add hover class to rows by mouseenter index
- Fix bug where collapsable rows needed 2 clicks to expand
- Use Ember.set instead of = when setting rowGroup’s data

Fix #8, Fix #13, Fix #10.
