### PR TITLE
Checks if on-load-more-rows returns a promise before calling finally method

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -77,7 +77,12 @@ export default Component.extend({
     viewportEntered() {
       if (this.getAttr('on-load-more-rows')) {
         this.set('isLoading', true);
-        this.attrs['on-load-more-rows']().finally(() => this.set('isLoading', false));
+        let promise = this.attrs['on-load-more-rows']();
+        if (promise) {
+          promise.finally(() => this.set('isLoading', false));
+        } else {
+          this.set('isLoading', false);
+        }
       }
     }
   }


### PR DESCRIPTION
There is an unexpected behavior when the paginated table gets to the last page. In order to implement the pagination functionality we need to implement the "on-load-more-rows" action, if we need to get the next page the function returns a promise with the api call otherwise it returns 'false'. Then on the the just-table addon we add a finally method to hide the 'Loading' label. The problem is when we receive 'false' because we are always making the finally call. Take a look at this screenshot http://screencast.com/t/dliyTeR6zx 

This change fixes this by checking if 'on-load-more-rows' execution returns a promise before calling the 'finally' method.
