### PR TITLE
table-row-class-added: Fixing table row when is on mouse hover

### DIFF
--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -26,7 +26,7 @@
           {{/if}}
         </tr>
         {{#each (get rowGroup rowGroupDataName) as |childRow|}}
-          <tr class="{{if rowGroup.isCollapsed 'is-collapsed'}}">
+          <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
             {{yield childRow}}
           </tr>
         {{else}}


### PR DESCRIPTION
The selected rows on the collapsible tables where made it an error when they had the mouse over. We just add the table-row class to the tr to fix that and have the hover method.
