### PR TITLE
Require on-load-more-rows to return a Promise

### DIFF
--- a/addon/components/in-viewport-checker.js
+++ b/addon/components/in-viewport-checker.js
@@ -23,9 +23,10 @@ export default Component.extend(InViewportMixin, {
 
   didEnterViewport() {
     let enterViewportAction = this.attrs['on-enter-viewport']();
-
-    if (enterViewportAction === false) {
-      this.destroy();
-    }
+    enterViewportAction.then((result) => {
+      if (!result) {
+        this.destroy();
+      }
+    });
   }
 });

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -76,8 +76,21 @@ export default Component.extend({
   actions: {
     viewportEntered() {
       if (this.getAttr('on-load-more-rows')) {
-        this.set('isLoading', true);
-        this.attrs['on-load-more-rows']().finally(() => this.set('isLoading', false));
+        let returnValue = this.getAttr('on-load-more-rows');
+        let isFunction  = typeof returnValue === 'function';
+
+        Ember.assert('on-load-more-rows must use a closure action', isFunction);
+
+        let promise = this.attrs['on-load-more-rows']();
+
+        if (!promise.then) {
+          promise = new RSVP.Promise((resolve) => {
+            resolve(false);
+          });
+        }
+
+        promise.finally(() => this.set('isLoading', false));
+        return promise;
       }
     }
   }

--- a/tests/dummy/app/pods/examples/infinite-loader-table/controller.js
+++ b/tests/dummy/app/pods/examples/infinite-loader-table/controller.js
@@ -4,7 +4,8 @@ import generateUsers from 'dummy/utils/generate-users';
 const {
   A,
   Controller,
-  computed
+  computed,
+  RSVP
 } = Ember;
 
 export default Controller.extend({
@@ -28,6 +29,9 @@ export default Controller.extend({
 
       users.pushObjects(newUsers);
       this.set('page', currentPage + 1);
+      return new RSVP.Promise((resolve) => {
+        resolve(users);
+      });
     }
   }
 });


### PR DESCRIPTION
- on-load-more-rows should return a Promise when fetching
- if it does not return a Promise, create a new Promise that resolves
  to false (used for removal of in-viewport-checker)
- assert that on-load-more-rows uses a closure action
