### PR TITLE
Refactor an each/else to an if/each/else to work around an Ember bug

### DIFF
--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -25,15 +25,17 @@
             {{yield rowGroup}}
           {{/if}}
         </tr>
-        {{#each (get rowGroup rowGroupDataName) as |childRow|}}
-          <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
-            {{yield childRow}}
-          </tr>
+        {{#if (get rowGroup rowGroupDataName)}}
+          {{#each (get rowGroup rowGroupDataName) as |childRow|}}
+            <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
+              {{yield childRow}}
+            </tr>
+          {{/each}}
         {{else}}
           <tr class="is-collapsed">
             {{yield}}
           </tr>
-        {{/each}}
+        {{/if}}
       {{/each}}
     {{else}}
       {{#each table.content as |row|}}


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/12716

This problem occurs when using a 'collapsable' table.
When a row group is initially rendered in the collapsed state it `yield`s; any `{{table-column}}` components rendered inside here aren't cleaned up properly (they're removed from the DOM but `willDestroyElement` is never called so they never unregister). The lack of unregistration means that the corresponding header will always hold a reference to this "frozen-in-time" component.
