### PR TITLE
Fix a bug where title would not be respected if it was an empty string

### DIFF
--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -62,7 +62,9 @@ export default Component.extend({
     @public
   */
   cellTitle: computed('title', '_value', function() {
-    return this.getAttr('title') || this.get('_value');
+    let value = this.get('_value');
+
+    return this.getWithDefault('title', value);
   }),
 
   /**

--- a/tests/integration/components/justa-table-test.js
+++ b/tests/integration/components/justa-table-test.js
@@ -111,3 +111,75 @@ test('adds rowClasses to rows', function(assert) {
   assert.ok(getRow(this, { row: 1 }).hasClass('hey'), 'row should have hey class');
   assert.ok(getRow(this, { row: 1 }).hasClass('man'), 'row should have man class');
 });
+
+test('title attribute defaults to value', function(assert) {
+  let content = [
+    { name: 'Fred' }
+  ];
+
+  this.set('content', content);
+
+  this.render(hbs`
+    {{#justa-table content=content as |table|}}
+      {{#table-columns table=table as |row|}}
+        {{table-column
+          row=row
+          headerName='foo'
+          valueBindingPath='name'}}
+
+      {{/table-columns}}
+    {{/justa-table}}
+  `);
+
+  assert.equal(this.$('td[title="Fred"]').length, 1, 'title attribute should default to value');
+});
+
+test('title attribute can be customized', function(assert) {
+  let content = [
+    { name: 'Fred' }
+  ];
+
+  this.set('content', content);
+
+  this.render(hbs`
+    {{#justa-table content=content as |table|}}
+      {{#table-columns table=table as |row|}}
+        {{table-column
+          row=row
+          title='whoa'
+          headerName='foo'
+          valueBindingPath='name'}}
+
+      {{/table-columns}}
+    {{/justa-table}}
+  `);
+
+  assert.equal(this.$('td[title="whoa"]').length, 1, 'title attribute should be whoa');
+});
+
+test('title attribute can be customized', function(assert) {
+  let content = [
+    {
+      person: {
+        name: 'fred'
+      }
+    }
+  ];
+
+  this.set('content', content);
+
+  this.render(hbs`
+    {{#justa-table content=content as |table|}}
+      {{#table-columns table=table as |row|}}
+        {{table-column
+          row=row
+          title=''
+          headerName='foo'
+          valueBindingPath='person'}}
+
+      {{/table-columns}}
+    {{/justa-table}}
+  `);
+
+  assert.equal(this.$('td[title=""]').length, 1, 'title attribute should be whoa');
+});


### PR DESCRIPTION
Background: to avoid showing a title on mouse hover, title should be passed as an empty string.

Fixes #32.
