### PR TITLE
Improve performance with large tables

### DIFF
--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -21,6 +21,17 @@ export default Component.extend({
   alignRight: computed.equal('align', 'right'),
 
   /**
+    Returns a valid table reference. Currently, collapsable and regular tables
+    have different parent implementations. For now, confine the private API mess
+    to a single place.
+    @public
+  */
+  table: computed(function() {
+    let table = get(this, 'parentView.parentView.parentView');
+    return table.get('registerColumn') ? table : get(this, 'parentView');
+  }).volatile(),
+
+  /**
     The header component this column should use to render its header.
     @public
     @default 'basic-header'
@@ -56,7 +67,7 @@ export default Component.extend({
   shouldUseFakeRowspan: computed('useFakeRowspan', function() {
     let { row, valueBindingPath } = getProperties(this, ['row', 'valueBindingPath']);
 
-    if (!valueBindingPath || get(this, 'hasBlock')) {
+    if (!row || !valueBindingPath || get(this, 'hasBlock')) {
       return;
     }
 
@@ -96,8 +107,7 @@ export default Component.extend({
     @private
   */
   _registerWithParent() {
-    // temp hack since we're no longer a direct child
-    let table = this.get('parentView.parentView.parentView');
+    let table = this.get('table');
     table.registerColumn(this);
     this.set('_registeredParent', table);
   },

--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -5,6 +5,8 @@ const {
   Component,
   computed,
   get,
+  getWithDefault,
+  getProperties,
   isEmpty,
   run,
   assert
@@ -51,20 +53,30 @@ export default Component.extend({
   */
   useFakeRowspan: false,
 
-  shouldUseFakeRowspan: computed('useFakeRowspan', '_value', function() {
-    let value = this.get('_value');
-    let useFakeRowspan = this.get('useFakeRowspan');
+  shouldUseFakeRowspan: computed('useFakeRowspan', function() {
+    let { row, valueBindingPath } = getProperties(this, ['row', 'valueBindingPath']);
+
+    if (!valueBindingPath || get(this, 'hasBlock')) {
+      return;
+    }
+
+    let value = get(row, valueBindingPath);
+    let useFakeRowspan = get(this, 'useFakeRowspan');
+
     return useFakeRowspan && isEmpty(value);
   }),
 
   /**
-    Return the title attribute for the tag with the cell value
+    Return the title attribute for the tag with the cell value.
+    If a title attribute is specified, it is used. Otherwise, title defaults to
+    the value of row.valueBindingPath, returning a blank string if not found.
     @public
   */
-  cellTitle: computed('title', '_value', function() {
-    let value = this.get('_value');
+  cellTitle: computed('title', 'valueBindingPath', function() {
+    let valueBindingPath = get(this, 'valueBindingPath');
+    let value = getWithDefault(this, `row.${valueBindingPath}`, '');
 
-    return this.getWithDefault('title', value);
+    return getWithDefault(this, 'title', value);
   }),
 
   /**
@@ -77,53 +89,31 @@ export default Component.extend({
     this._super(...arguments);
     assert('Must use table column as a child of table-columns or fixed-table-columns.', this.parentView);
     run.scheduleOnce('actions', this, this._registerWithParent);
-
-    this._setValueDependentKeys();
   },
 
   /**
-    Sets dependent keys on the _value computed property. This is done since
-    we need to clear the cached version based on a dynamic key, and volatile()
-    does not do the needful.
-    @private
-  **/
-  _setValueDependentKeys() {
-    const path = this.get('valueBindingPath');
-    const pathKey = `row.${path}`;
-    this._value.property('valueBindingPath', 'row', pathKey);
-  },
-
-  /**
-    Return the value for the cell based on row.valueBindingPath. Only used if
-    a block is not passed, the path is provided, and the row is not empty.
-    @private
-  */
-  _value: computed('valueBindingPath', 'row', function() {
-    const path = this.get('valueBindingPath');
-    const row = this.get('row');
-    const hasBlockParams = this.get('hasBlockParams');
-
-    if (hasBlockParams || isEmpty(path) || isEmpty(row)) {
-      return null;
-    }
-
-    return get(row, path);
-  }),
-
-  /**
-    Register this column with its parent view.
+    Register this column with its parent table.
     @private
   */
   _registerWithParent() {
-    let parent = this.get('parentView');
-    parent.registerColumn(this);
-    this.set('_registeredParent', parent);
+    // temp hack since we're no longer a direct child
+    let table = this.get('parentView.parentView.parentView');
+    table.registerColumn(this);
+    this.set('_registeredParent', table);
   },
 
   willDestroyElement() {
     let parent = this.get('_registeredParent');
     if (parent) {
-      parent.unregisterColumn(this);
+      run.scheduleOnce('actions', this, this._unregisterWithParent, parent);
     }
+  },
+
+  /**
+    Unregister this column with its parent table.
+    @private
+  */
+  _unregisterWithParent(parent) {
+    parent.unregisterColumn(this);
   }
 });

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -119,7 +119,7 @@ export default Ember.Component.extend({
 
   _onRowEnter() {
     let rowIndex = this.$('tr').index(this.$('tr:hover'));
-    this.get('table').$(`tr.table-row:nth-child(${rowIndex})`).addClass('hover');
+    this.get('table').$(`tr.table-row:nth-of-type(${rowIndex})`).addClass('hover');
   },
 
   _onRowLeave() {

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -4,12 +4,15 @@ import layout from '../templates/components/table-columns';
 const {
   A,
   get,
+  getWithDefault,
   set,
   isEmpty,
   isNone,
   computed,
   computed: { readOnly }
 } = Ember;
+
+const DEFAULT_ROW_HEIGHT = 37;
 
 export default Ember.Component.extend({
   layout,
@@ -55,17 +58,12 @@ export default Ember.Component.extend({
   }),
 
   /**
-    Sets an inline style for height on all table rows from table.rowHeight.
+    Gets table's rowHeight.
     @public
+    @default DEFAULT_ROW_HEIGHT
   */
   rowHeight: computed('table.rowHeight', function() {
-    let rowHeight = this.get('table.rowHeight');
-
-    if (rowHeight) {
-      return new Ember.Handlebars.SafeString(`height: ${rowHeight}`);
-    }
-
-    return new Ember.Handlebars.SafeString('');
+    return getWithDefault(this, 'table.rowHeight', DEFAULT_ROW_HEIGHT);
   }),
 
   /**
@@ -121,11 +119,11 @@ export default Ember.Component.extend({
 
   _onRowEnter() {
     let rowIndex = this.$('tr').index(this.$('tr:hover'));
-    this.getAttr('table').$(`tr.table-row:nth-child(${rowIndex})`).addClass('hover');
+    this.get('table').$(`tr.table-row:nth-child(${rowIndex})`).addClass('hover');
   },
 
   _onRowLeave() {
-    this.getAttr('table').$('tr').removeClass('hover');
+    this.get('table').$('tr').removeClass('hover');
   },
 
   actions: {

--- a/addon/templates/components/table-column.hbs
+++ b/addon/templates/components/table-column.hbs
@@ -1,2 +1,5 @@
-{{_value}}
-{{yield}}
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{get row valueBindingPath}}
+{{/if}}

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -11,18 +11,45 @@
     </tr>
   </thead>
 
-  {{#vertical-collection
-    tagName="tbody"
-    itemClassNames=(concat 'table-row ' mergedRowClasses)
-    content=table.content
-    defaultHeight=rowHeight
-    bufferSize=0.5
-    alwaysUseDefaultHeight=true
-    scrollThrottle=16
-    containerSelector=".justa-table"
-    as |row|}}
+  {{#if table.collapsable}}
+    {{#each table.content as |rowGroup|}}
+      <tr class="table-row {{mergedRowClasses}} collapsable {{if (eq rowGroup.isCollapsed false) 'is-expanded' 'is-collapsed'}} {{if rowGroup.loading 'is-loading'}}" {{action 'toggleRowCollapse' rowGroup}}>
+        {{#if rowGroup.label}}
+          <td colspan={{columns.length}} class="table-cell">
+            {{rowGroup.label}}
+          </td>
+        {{else}}
+          {{yield rowGroup}}
+        {{/if}}
+      </tr>
 
-    {{yield row}}
+      {{#if (get rowGroup rowGroupDataName)}}
+        {{#each (get rowGroup rowGroupDataName) as |childRow|}}
+          <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
+            {{yield childRow}}
+          </tr>
+        {{/each}}
+      {{else}}
+        <tr class="is-collapsed">
+          {{yield}}
+        </tr>
+      {{/if}}
 
-  {{/vertical-collection}}
+    {{/each}}
+  {{else}}
+    {{#vertical-collection
+      tagName="tbody"
+      itemClassNames=(concat 'table-row ' mergedRowClasses)
+      content=table.content
+      defaultHeight=rowHeight
+      bufferSize=0.5
+      alwaysUseDefaultHeight=true
+      scrollThrottle=16
+      containerSelector=".justa-table"
+      as |row|}}
+
+      {{yield row}}
+
+    {{/vertical-collection}}
+  {{/if}}
 </table>

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -11,38 +11,18 @@
     </tr>
   </thead>
 
-  <tbody>
-    {{! TODO: render diff template instead of this if }}
-    {{#if table.collapsable}}
-      {{#each table.content as |rowGroup|}}
-        <tr class="table-row {{mergedRowClasses}} collapsable {{if (eq rowGroup.isCollapsed false) 'is-expanded' 'is-collapsed'}} {{if rowGroup.loading 'is-loading'}}" {{action 'toggleRowCollapse' rowGroup}}>
+  {{#vertical-collection
+    tagName="tbody"
+    itemClassNames=(concat 'table-row ' mergedRowClasses)
+    content=table.content
+    defaultHeight=rowHeight
+    bufferSize=0.5
+    alwaysUseDefaultHeight=true
+    scrollThrottle=16
+    containerSelector=".justa-table"
+    as |row|}}
 
-          {{#if rowGroup.label}}
-            <td colspan={{columns.length}} class="table-cell">
-              {{rowGroup.label}}
-            </td>
-          {{else}}
-            {{yield rowGroup}}
-          {{/if}}
-        </tr>
-        {{#if (get rowGroup rowGroupDataName)}}
-          {{#each (get rowGroup rowGroupDataName) as |childRow|}}
-            <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
-              {{yield childRow}}
-            </tr>
-          {{/each}}
-        {{else}}
-          <tr class="is-collapsed">
-            {{yield}}
-          </tr>
-        {{/if}}
-      {{/each}}
-    {{else}}
-      {{#each table.content as |row|}}
-        <tr class="table-row {{mergedRowClasses}}" style={{rowHeight}}>
-          {{yield row}}
-        </tr>
-      {{/each}}
-    {{/if}}
-  </tbody>
+    {{yield row}}
+
+  {{/vertical-collection}}
 </table>

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -4,10 +4,8 @@
   width: 100%;
   border-collapse: collapse;
   border-spacing: 0;
-
-  // TODO: only need if forced fixed height
-  //height: 700px;
-  //overflow: auto;
+  max-height: 500px;
+  overflow: scroll;
 
   tr {
     height: 36px;
@@ -29,6 +27,13 @@
     }
   }
 
+  th {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
   th.text-wrap {
     white-space: normal;
   }
@@ -41,6 +46,11 @@
 
   .table-columns {
     overflow: auto;
+    // display: block;
+    // height: 500px;
+    // max-height: 500px;
+    // overflow: scroll;
+    // position: relative;
   }
 
   .fixed-table-columns {

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "justa-table",
   "dependencies": {
     "bootstrap-sass": "3.3.5",
-    "ember": "1.13.10",
+    "ember": "2.4.2",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.1.3",
     "ember-load-initializers": "#0.1.7",
@@ -13,6 +13,7 @@
     "jquery": "2.1.4",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
-    "showdown": "~1.3.0"
+    "showdown": "~1.3.0",
+    "animation-frame": "~0.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "broccoli-funnel": "0.2.11",
     "broccoli-source": "1.1.0",
     "ember-ajax": "0.6.4",
+    "ember-async-image": "0.1.1",
     "ember-cli": "1.13.8",
     "ember-cli-active-link-wrapper": "0.0.4",
     "ember-cli-app-version": "0.5.0",
@@ -43,6 +44,7 @@
     "ember-export-application-global": "^1.0.3",
     "ember-faker": "1.1.0",
     "ember-get-helper": "1.0.4",
+    "ember-run-raf": "1.1.1",
     "ember-suave": "1.2.3",
     "ember-try": "0.0.8"
   },
@@ -50,11 +52,12 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^0.7.9",
     "ember-cli-sass": "^5.1.0",
     "ember-in-viewport": "2.0.4",
-    "ember-truth-helpers": "^1.0.0"
+    "ember-truth-helpers": "^1.0.0",
+    "smoke-and-mirrors": "cball/smoke-and-mirrors#2c265a4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/acceptance/table-rerenders-when-rows-change-test.js
+++ b/tests/acceptance/table-rerenders-when-rows-change-test.js
@@ -20,7 +20,7 @@ test('basic table properly re-renders when rows are removed', function(assert) {
     let rows = $('.table-columns tr').length;
     let headers = $('.table-columns th').text().trim();
 
-    assert.equal(rows, 51, 'should have 50 rows + header');
+    assert.equal(rows, 101, 'should have 50 rows + header');
     assert.ok(headers.match(/name/i), 'should have name header');
     assert.ok(headers.match(/image/i), 'should have image header');
   });

--- a/tests/dummy/app/pods/examples/basic-table/route.js
+++ b/tests/dummy/app/pods/examples/basic-table/route.js
@@ -4,7 +4,7 @@ import faker from 'faker';
 export default Ember.Route.extend({
   model() {
     let users = [];
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
       let user = Ember.Object.create({
         displayName: faker.name.findName(),
         image: faker.image.avatar(),

--- a/tests/dummy/app/pods/examples/fixed-column-table/route.js
+++ b/tests/dummy/app/pods/examples/fixed-column-table/route.js
@@ -4,7 +4,7 @@ import faker from 'faker';
 export default Ember.Route.extend({
   model() {
     let users = [];
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
       let user = Ember.Object.create({
         displayName: faker.name.findName(),
         address: faker.address.streetAddress(),

--- a/tests/integration/components/justa-table-test.js
+++ b/tests/integration/components/justa-table-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('justa-table', 'Integration | Component | justa table', {
   integration: true
@@ -36,10 +37,13 @@ test('it renders content', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.equal(this.$('th').text().trim(), 'foo', 'our column was named foo');
-  assert.equal(this.$('tr').length, 4, 'should have 2 rows and a header row');
-  assert.equal(getCell(this, { row: 1, cell: 1 }).text().trim(), 'Fred', 'first cell should be Fred');
-  assert.equal(getCell(this, { row: 2, cell: 1 }).text().trim(), 'Wilma', 'first cell should be Wilma');
+  return wait().then(() => {
+    assert.equal(this.$('th').text().trim(), 'foo', 'our column was named foo');
+    assert.equal(this.$('tr').length, 4, 'should have 2 rows and a header row');
+    assert.equal(getCell(this, { row: 1, cell: 1 }).text().trim(), 'Fred', 'first cell should be Fred');
+    assert.equal(getCell(this, { row: 2, cell: 1 }).text().trim(), 'Wilma', 'first cell should be Wilma');
+  });
+
 });
 
 test('adds a fake rowspan class if cell content isEmpty and useFakeRowspan is true', function(assert) {
@@ -64,7 +68,9 @@ test('adds a fake rowspan class if cell content isEmpty and useFakeRowspan is tr
     {{/justa-table}}
   `);
 
-  assert.ok(getCell(this, { row: 3, cell: 1 }).hasClass('fake-rowspan'));
+  return wait().then(() => {
+    assert.ok(getCell(this, { row: 3, cell: 1 }).hasClass('fake-rowspan'));
+  });
 });
 
 test('passes rowHeight to rows', function(assert) {
@@ -75,8 +81,8 @@ test('passes rowHeight to rows', function(assert) {
   this.set('content', content);
 
   this.render(hbs`
-    {{#justa-table content=content as |table|}}
-      {{#table-columns table=table rowHeight='40px' as |row|}}
+    {{#justa-table content=content rowHeight='40px' as |table|}}
+      {{#table-columns table=table as |row|}}
         {{table-column
           row=row
           headerName='foo'
@@ -86,7 +92,9 @@ test('passes rowHeight to rows', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.equal(getRow(this, { row: 1 }).attr('style'), '40px', 'row height should be 40px');
+  return wait().then(() => {
+    assert.equal(getRow(this, { row: 1 }).attr('style').trim(), 'height: 40px;', 'row height should be 40px');
+  });
 });
 
 test('adds rowClasses to rows', function(assert) {
@@ -108,8 +116,11 @@ test('adds rowClasses to rows', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.ok(getRow(this, { row: 1 }).hasClass('hey'), 'row should have hey class');
-  assert.ok(getRow(this, { row: 1 }).hasClass('man'), 'row should have man class');
+  return wait().then(() => {
+    assert.ok(getRow(this, { row: 1 }).hasClass('hey'), 'row should have hey class');
+    assert.ok(getRow(this, { row: 1 }).hasClass('man'), 'row should have man class');
+    assert.ok(getRow(this, { row: 1 }).hasClass('table-row'), 'row should have default row class');
+  });
 });
 
 test('title attribute defaults to value', function(assert) {
@@ -131,7 +142,9 @@ test('title attribute defaults to value', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.equal(this.$('td[title="Fred"]').length, 1, 'title attribute should default to value');
+  return wait().then(() => {
+    assert.equal(this.$('td[title="Fred"]').length, 1, 'title attribute should default to value');
+  });
 });
 
 test('title attribute can be customized', function(assert) {
@@ -154,7 +167,9 @@ test('title attribute can be customized', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.equal(this.$('td[title="whoa"]').length, 1, 'title attribute should be whoa');
+  return wait().then(() => {
+    assert.equal(this.$('td[title="whoa"]').length, 1, 'title attribute should be whoa');
+  });
 });
 
 test('title attribute can be customized', function(assert) {
@@ -181,5 +196,35 @@ test('title attribute can be customized', function(assert) {
     {{/justa-table}}
   `);
 
-  assert.equal(this.$('td[title=""]').length, 1, 'title attribute should be whoa');
+  return wait().then(() => {
+    assert.equal(this.$('td[title=""]').length, 1, 'title attribute should be empty string');
+  });
+});
+
+test('title attribute returns blank if invalid valueBindingPath', function(assert) {
+  let content = [
+    {
+      person: {
+        name: 'fred'
+      }
+    }
+  ];
+
+  this.set('content', content);
+
+  this.render(hbs`
+    {{#justa-table content=content as |table|}}
+      {{#table-columns table=table as |row|}}
+        {{table-column
+          row=row
+          headerName='foo'
+          valueBindingPath='asdf'}}
+
+      {{/table-columns}}
+    {{/justa-table}}
+  `);
+
+  return wait().then(() => {
+    assert.equal(this.$('td[title=""]').length, 1, 'title attribute should be empty string');
+  });
 });


### PR DESCRIPTION
- [x] Fix "you modified columns 2x in a single render" error
- [x] Remove concept of `_value`. It was meant to be private and was being extended for use
- [x] Use smoke and mirrors `vertical-collection` to more efficiently render large lists
- [x] Don't allow user to select text in headers (avoids highlighting when resizing)
- [x] Add classes back to tr's, will fix highlight
- [x] Put back collapsable table template

Further improvements should be able to be made by hiding horizontal content offscreen (currently its just vertical), but best to wait for https://github.com/runspired/smoke-and-mirrors/pull/98 which should provide this behavior out of the box.

FIxes #18, Fixes #38
