### PR TITLE
Dynamically change height of tables after render

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -24,6 +24,13 @@ export default Component.extend({
   },
 
   /**
+    The initial / max height of the table, will overflow if rows exceed this
+    number.
+    @public
+  */
+  tableHeight: 500,
+
+  /**
     If the table should use pagination. Will fire the 'on-load-more-rows'
     action when it enters the viewport.
     @public
@@ -72,10 +79,24 @@ export default Component.extend({
 
     fixedHeader.height(maxHeight);
     columnHeader.height(maxHeight);
+
+    this._resizeTable();
   },
 
   /**
-    Queues sending 'didRenderTable' action.
+    Sets the table height before rendering. If the height of the rows is less
+    than the specified tableHeight, it will resize.
+    @private
+  */
+  _resizeTable() {
+    let requestedHeight = this.get('tableHeight');
+    let actualHeight = this.$('table').outerHeight();
+    this.$().height(Math.min(requestedHeight, actualHeight));
+  },
+
+  /**
+    Queues sending 'didRenderTable' action. This is called once the columns
+    have rendered data.
     @public
   */
   didRenderCollection() {


### PR DESCRIPTION
- adds tableHeight property, defaults to 500
- after render, set the height of the table. If the rows don’t fill the
  entire height, table height will be set to the length of the rows.
