### PR TITLE
Add Sticky Headers

### DIFF
--- a/addon/components/fixed-table-columns.js
+++ b/addon/components/fixed-table-columns.js
@@ -13,7 +13,6 @@ export default TableColumns.extend({
   init() {
     this._super(...arguments);
     assert('fixed columns cannot be resizable', !this.resizable);
-    // this.classNames = ['fixed-table-columns'];
   },
 
   /**
@@ -35,7 +34,6 @@ export default TableColumns.extend({
   actions: {
     columnWidthChanged() {
       this._super(...arguments);
-      this._setTableWidth();
     }
   }
 });

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -13,7 +13,7 @@ const {
 export default Component.extend({
   layout,
   classNames: ['justa-table'],
-  classNameBindings: ['isLoading'],
+  classNameBindings: ['isLoading', 'stickyHeaders'],
 
   init() {
     this._super(...arguments);
@@ -90,7 +90,7 @@ export default Component.extend({
   */
   _resizeTable() {
     let requestedHeight = this.get('tableHeight');
-    let actualHeight = this.$('table').outerHeight();
+    let actualHeight = this.$('.table-columns table').outerHeight();
     let totalHeight = Math.min(requestedHeight, actualHeight);
 
     this.$().height(totalHeight);
@@ -125,6 +125,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
+    this._super(...arguments);
     this._setupListeners();
   },
 

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -10,9 +10,7 @@
     border-right: 1px solid #666;
   }
 
-  /* TODO: pass row height in table setup when cloaking? */
   td {
-    // height: 32px;
     padding: 7px 10px;
     line-height: 16px;
     border-right: 1px solid #e5e5e5;

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "showdown": "~1.3.0",
-    "animation-frame": "~0.2.4"
+    "animation-frame": "~0.2.4",
+    "jquery.floatThead": "^1.3.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,5 +5,7 @@ module.exports = {
   name: 'justa-table',
   included: function(app) {
     this._super.included(app);
+
+    app.import('bower_components/jquery.floatThead/dist/jquery.floatThead.js');
   }
 };

--- a/tests/dummy/app/pods/components/examples-navbar/template.hbs
+++ b/tests/dummy/app/pods/components/examples-navbar/template.hbs
@@ -1,21 +1,24 @@
 {{#active-link}}
-  {{#link-to 'examples.basic-table'}}Basic Table{{/link-to}}
+  {{#link-to 'examples.basic-table'}}Basic{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.fixed-column-table'}}Fixed Columns{{/link-to}}
+  {{#link-to 'examples.fixed-column-table'}}Fixed Col{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.resizable-columns-table'}}Resizable Columns{{/link-to}}
+  {{#link-to 'examples.resizable-columns-table'}}Resizable Col{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.infinite-loader-table'}}Infinite Loader{{/link-to}}
+  {{#link-to 'examples.infinite-loader-table'}}Infinite Load{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.collapsable-table'}}Collapsable Table{{/link-to}}
+  {{#link-to 'examples.collapsable-table'}}Collapsable{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.collapsable-table-with-ajax'}}Collapsable Table with AJAX{{/link-to}}
+  {{#link-to 'examples.collapsable-table-with-ajax'}}Collapsable w/ AJAX{{/link-to}}
 {{/active-link}}
 {{#active-link}}
-  {{#link-to 'examples.group-by-name'}}Group With Matching Prior Row{{/link-to}}
+  {{#link-to 'examples.group-by-name'}}Group w/ Prior Row{{/link-to}}
+{{/active-link}}
+{{#active-link}}
+  {{#link-to 'examples.sticky-headers'}}Sticky Headers{{/link-to}}
 {{/active-link}}

--- a/tests/dummy/app/pods/examples/sticky-headers/route.js
+++ b/tests/dummy/app/pods/examples/sticky-headers/route.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import faker from 'faker';
+
+export default Ember.Route.extend({
+  model() {
+    let users = [];
+    for (let i = 0; i < 100; i++) {
+      let user = Ember.Object.create({
+        displayName: faker.name.findName(),
+        address: faker.address.streetAddress(),
+        city: faker.address.city(),
+        state: faker.address.state(),
+        zipCode: faker.address.zipCode(),
+        company: faker.company.companyName()
+      });
+
+      users.push(user);
+    }
+
+    return users;
+  }
+});

--- a/tests/dummy/app/pods/examples/sticky-headers/template.hbs
+++ b/tests/dummy/app/pods/examples/sticky-headers/template.hbs
@@ -1,0 +1,44 @@
+{{#justa-table content=model stickyHeaders=true as |table|}}
+  {{#fixed-table-columns table=table as |row|}}
+    {{table-column
+      row=row
+      width=150
+      headerName='Name'
+      valueBindingPath='displayName'}}
+
+    {{table-column
+      row=row
+      width=250
+      headerName='Company'
+      valueBindingPath='company'}}
+  {{/fixed-table-columns}}
+
+  {{#table-columns table=table as |row|}}
+
+    {{table-column
+      row=row
+      width=550
+      headerName='Address'
+      resizable=true
+      valueBindingPath='address'}}
+
+    {{table-column
+      row=row
+      width=150
+      headerName='City'
+      valueBindingPath='city'}}
+
+    {{table-column
+      row=row
+      width=150
+      headerName='State'
+      valueBindingPath='state'}}
+
+    {{table-column
+      row=row
+      width=150
+      headerName='Zip'
+      valueBindingPath='zipCode'}}
+
+  {{/table-columns}}
+{{/justa-table}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -14,6 +14,7 @@ Router.map(function() {
     this.route('collapsable-table');
     this.route('collapsable-table-with-ajax');
     this.route('group-by-name');
+    this.route('sticky-headers');
   });
 });
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -16,14 +16,8 @@ $icon-font-path: '/assets/bootstrap/';
 }
 
 .danger-cell {
-  animation: blink 1s step-end infinite;
-  background: #333;
+  background: #554339;
   color: white;
-}
-
-@keyframes blink {
-	0% {background-color: #802456}
-	50% {background-color: #554339}
 }
 
 .collapsable {
@@ -35,5 +29,11 @@ $icon-font-path: '/assets/bootstrap/';
 
   &.is-collapsed td:before {
     content: '👉';
+  }
+}
+
+.sticky-headers {
+  th {
+    background: rgb(238, 158, 31);
   }
 }


### PR DESCRIPTION
- Removes unnecessary cruft in fixed-table-columns
- adds `stickyHeaders` classNameBinding
- scopes the setting of table height to table-columns
- adds some missing super calls
- reflows sticky headers on column add/remove
- reflows sticky headers on column width change

Fixes #39
