### PR TITLE
change default styles a bit.

### DIFF
--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -17,7 +17,15 @@
     background: none;
   }
 
-  .fixed-table-columns {
+  tr {
+    background: white;
+  }
+
+  .fixed-table-columns-wrapper {
+    tr {
+      background: none;
+    }
+
     tr:hover {
       background: none;
     }

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -54,7 +54,10 @@
     height: 500px;
     max-height: 500px;
     position: relative;
-    background: white;
+
+    tr {
+      background: white;
+    }
   }
 
   .fixed-table-columns-wrapper {


### PR DESCRIPTION
Make the bg on the rows instead of the table-columns-div.

Avoids a strange issue in chrome where the table is blank if there are
fixed columns present but no other columns.
