### PR TITLE
Move collapsable tables to smoke-and-mirrors

### DIFF
--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -3,11 +3,7 @@ import layout from '../templates/components/table-columns';
 
 const {
   A,
-  get,
   getWithDefault,
-  set,
-  isEmpty,
-  isNone,
   computed,
   computed: { readOnly },
   run: { scheduleOnce }
@@ -89,6 +85,7 @@ export default Ember.Component.extend({
   mergedRowClasses: computed('table.rowClasses', 'rowClasses', function() {
     let tableClasses = this.get('table.rowClasses');
     let rowClasses = this.get('rowClasses');
+
     return new A([tableClasses, rowClasses]).compact().join(' ');
   }),
 
@@ -269,29 +266,6 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    // TODO: move to collapse table
-    toggleRowCollapse(rowGroup) {
-      let collapsed = get(rowGroup, 'isCollapsed');
-
-      if (isNone(collapsed)) {
-        set(rowGroup, 'isCollapsed', false);
-      } else {
-        set(rowGroup, 'isCollapsed', !rowGroup.isCollapsed);
-      }
-      // TODO make this smarter by taking option if we should do this
-      let rowData = get(rowGroup, this.get('rowGroupDataName'));
-      let shouldFetch = isEmpty(rowData) && !rowGroup.isCollapsed;
-
-      if (shouldFetch) {
-        set(rowGroup, 'loading', true);
-        this.attrs.onRowExpand(rowGroup).then((data) => {
-          set(rowGroup, this.get('rowGroupDataName'), rowData.concat(data));
-        }).finally(() => {
-          set(rowGroup, 'loading', false);
-        });
-      }
-    },
-
     columnWidthChanged(/* column, newWidth */) {
       this.reflowStickyHeaders();
     }

--- a/addon/components/table-vertical-collection.js
+++ b/addon/components/table-vertical-collection.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import layout from '../templates/components/table-vertical-collection';
+import VerticalCollection from 'smoke-and-mirrors/components/vertical-collection';
+
+export default VerticalCollection.extend({
+  layout,
+  'on-row-click': Ember.K
+});

--- a/addon/components/table-vertical-item.js
+++ b/addon/components/table-vertical-item.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import layout from '../templates/components/table-vertical-item';
+import VerticalItem from 'smoke-and-mirrors/components/vertical-item';
+
+const {
+  get,
+  computed,
+  computed: { readOnly }
+} = Ember;
+
+export default VerticalItem.extend({
+  layout,
+  classNameBindings: ['isLoading', 'collapsable', 'isCollapsed:is-collapsed:is-expanded'],
+
+  isLoading: readOnly('content.loading'),
+  collapsable: computed('content.isParent', function() {
+    let isParent = get(this, 'content.isParent');
+    return isParent === true;
+  }),
+
+  isCollapsed: computed('content.isCollapsed', function() {
+    let isCollapsed = get(this, 'content.isCollapsed');
+    return isCollapsed === true;
+  })
+});

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -13,32 +13,25 @@
     </thead>
 
     {{#if table.collapsable}}
-      <tbody>
-        {{#each table.content as |rowGroup|}}
-          <tr class="table-row {{mergedRowClasses}} collapsable {{if (eq rowGroup.isCollapsed false) 'is-expanded' 'is-collapsed'}} {{if rowGroup.loading 'is-loading'}}" {{action 'toggleRowCollapse' rowGroup}}>
-            {{#if rowGroup.label}}
-              <td colspan={{columns.length}} class="table-cell">
-                {{rowGroup.label}}
-              </td>
-            {{else}}
-              {{yield rowGroup}}
-            {{/if}}
-          </tr>
+      {{#table-vertical-collection
+        tagName="tbody"
+        itemClassNames=(concat 'table-row ' mergedRowClasses)
+        content=table.collapseTableData
+        defaultHeight=rowHeight
+        bufferSize=0.5
+        alwaysUseDefaultHeight=true
+        containerSelector=".table-columns"
+        on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
 
-          {{#if (get rowGroup rowGroupDataName)}}
-            {{#each (get rowGroup rowGroupDataName) as |childRow|}}
-              <tr class="table-row {{if rowGroup.isCollapsed 'is-collapsed'}}">
-                {{yield childRow}}
-              </tr>
-            {{/each}}
-          {{else}}
-            <tr class="is-collapsed">
-              {{yield}}
-            </tr>
-          {{/if}}
+        {{#if row.label}}
+          <td colspan={{columns.length}} class="table-cell">
+            {{row.label}}
+          </td>
+        {{else if (or row.isParent (not row.parent.IsCollapsed))}}
+          {{yield row}}
+        {{/if}}
 
-        {{/each}}
-      </tbody>
+      {{/table-vertical-collection}}
     {{else}}
       {{#vertical-collection
         tagName="tbody"
@@ -47,7 +40,6 @@
         defaultHeight=rowHeight
         bufferSize=0.5
         alwaysUseDefaultHeight=true
-        scrollThrottle=16
         containerSelector=".table-columns"
         as |row|}}
 

--- a/addon/templates/components/table-vertical-collection.hbs
+++ b/addon/templates/components/table-vertical-collection.hbs
@@ -1,0 +1,19 @@
+{{#each _content key='@index' as |item index|}}
+  {{#table-vertical-item
+    itemTagName=itemTagName
+    class=itemClassNames
+    defaultHeight=defaultHeight
+    alwaysUseDefaultHeight=alwaysUseDefaultHeight
+    content=item
+    index=index
+    register=(action register)
+    unregister=(action unregister)
+    click=(action on-row-click item index)
+  }}
+    {{#if shouldRenderList}}
+      {{yield item index}}
+    {{/if}}
+  {{/table-vertical-item}}
+{{else}}
+  {{yield to="inverse"}}
+{{/each}}

--- a/addon/templates/components/table-vertical-item.hbs
+++ b/addon/templates/components/table-vertical-item.hbs
@@ -1,0 +1,3 @@
+{{#if contentInserted}}
+  {{yield}}
+{{/if}}

--- a/app/components/table-vertical-collection.js
+++ b/app/components/table-vertical-collection.js
@@ -1,0 +1,1 @@
+export { default } from 'justa-table/components/table-vertical-collection';

--- a/app/components/table-vertical-item.js
+++ b/app/components/table-vertical-item.js
@@ -1,0 +1,1 @@
+export { default } from 'justa-table/components/table-vertical-item';

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -2,10 +2,6 @@
   margin-bottom: 1em;
   border: 1px solid #e5e5e5;
 
-  tr:hover, tr.hover {
-    background: #e9f7f7;
-  }
-
   th {
     border-right: 1px solid #666;
   }
@@ -19,6 +15,14 @@
 
   tr {
     background: white;
+
+    &.collapsable {
+      cursor: pointer;
+    }
+  }
+
+  tr:hover, tr.hover {
+    background: #e9f7f7;
   }
 
   .fixed-table-columns-wrapper {

--- a/tests/dummy/app/pods/examples/collapsable-table-with-ajax/route.js
+++ b/tests/dummy/app/pods/examples/collapsable-table-with-ajax/route.js
@@ -2,23 +2,29 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model() {
-    return [
-      {
-        label: 'Happy Users',
-        isCollapsed: true,
-        data: []
-      },
-      {
-        label: 'Crazy Users',
-        isCollapsed: true,
-        data: []
-      },
-      {
-        label: 'Super Users',
-        isCollapsed: true,
-        data: []
-      }
-    ];
+    let users = [];
+
+    for (let i = 0; i < 30; i++) {
+      users = users.concat([
+        {
+          label: 'Happy Users',
+          isCollapsed: true,
+          data: []
+        },
+        {
+          label: 'Crazy Users',
+          isCollapsed: true,
+          data: []
+        },
+        {
+          label: 'Super Users',
+          isCollapsed: true,
+          data: []
+        }
+      ]);
+    }
+
+    return users;
   },
 
   actions: {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -25,10 +25,15 @@ $icon-font-path: '/assets/bootstrap/';
 
   & td:before {
     content: '👇';
+    display: inline-block;
   }
 
   &.is-collapsed td:before {
     content: '👉';
+  }
+
+  &.is-loading td:before {
+    animation:spin 1s linear infinite;
   }
 }
 
@@ -37,3 +42,7 @@ $icon-font-path: '/assets/bootstrap/';
     background: rgb(238, 158, 31);
   }
 }
+
+@-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
+@-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
+@keyframes spin { 100% { transform:rotate(360deg); } }

--- a/tests/integration/components/justa-table-test.js
+++ b/tests/integration/components/justa-table-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
+import Ember from 'ember';
 
 moduleForComponent('justa-table', 'Integration | Component | justa table', {
   integration: true
@@ -250,9 +251,7 @@ test('title attribute can be customized', function(assert) {
 test('title attribute returns blank if invalid valueBindingPath', function(assert) {
   let content = [
     {
-      person: {
-        name: 'fred'
-      }
+      name: 'fred'
     }
   ];
 
@@ -272,5 +271,49 @@ test('title attribute returns blank if invalid valueBindingPath', function(asser
 
   return wait().then(() => {
     assert.equal(this.$('td[title=""]').length, 1, 'title attribute should be empty string');
+  });
+});
+
+test('adds a click listener to table rows', function(assert) {
+  assert.expect(2);
+
+  let done = assert.async();
+  let content = [
+    {
+      name: 'fred',
+      data: []
+    }
+  ];
+
+  this.setProperties({
+    content,
+    actions: {
+      foo() {
+        assert.ok(true, 'clicking a row should call action');
+        done();
+        return Ember.RSVP.Promise.resolve([]);
+      }
+    }
+  });
+
+  this.render(hbs`
+    {{#justa-table
+      content=content
+      collapsable=true
+      onRowExpand=(action 'foo') as |table|}}
+
+      {{#table-columns table=table as |row|}}
+        {{table-column
+          row=row
+          headerName='foo'
+          valueBindingPath='name'}}
+
+      {{/table-columns}}
+    {{/justa-table}}
+  `);
+
+  return wait().then(() => {
+    assert.ok(this.$('.table-row').hasClass('collapsable'));
+    this.$('.table-row').click();
   });
 });


### PR DESCRIPTION
- BREAKING CHANGE: `onRowExpand` moves to table where it belongs
- ensures content is formatted properly for collapse tables
- adds table and column aliases to `table-column` using nearestOfType
- run groupWithPriorRow on didReceiveAttrs to handle newly rendered
  rows in collapse tables
- reworks groupWithPriorRow
- adds table-vertical-collection to handle row click
- adds table-vertical-item to provide loading / collapse classes to rows
- uses table-vertical-collection for collapsable tables

Fixes #56
