### PR TITLE
Setup sticky headers on scroll. Scope hover to .table-row elements.

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -122,7 +122,6 @@ export default Component.extend({
   */
   didRenderCollection() {
     run.scheduleOnce('afterRender', this, this._sendRenderAction);
-    this.ensureEqualHeaderHeight();
   },
 
   /**
@@ -166,8 +165,31 @@ export default Component.extend({
     let columns = this.$('.table-columns');
 
     columns.scroll((e) => {
+      this._setupStickyHeaders();
       columns.not(e.target).scrollTop(e.target.scrollTop);
     });
+  },
+
+  _setupStickyHeaders() {
+    let hasSetupStickyHeaders = this.get('hasSetupStickyHeaders');
+    if (hasSetupStickyHeaders) {
+      return;
+    }
+
+    let usingStickyHeaders = this.get('stickyHeaders');
+
+    if (usingStickyHeaders) {
+      this.set('hasSetupStickyHeaders', true);
+
+      window.requestAnimationFrame(() => {
+        this.$('table').floatThead({
+          position: 'absolute',
+          scrollContainer($table) {
+            return $table.closest('.table-columns');
+          }
+        });
+      });
+    }
   },
 
   /**

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -143,27 +143,8 @@ export default Ember.Component.extend({
   },
 
   didInsertElement() {
-    this._setupStickyHeaders();
-
     this.$().on('mouseenter', 'tr', this._onRowEnter.bind(this));
     this.$().on('mouseleave', 'tr', this._onRowLeave.bind(this));
-  },
-
-  /**
-    Installs the sticky headers plugin if the table should use it.
-    @private
-  */
-  _setupStickyHeaders() {
-    let usingStickyHeaders = this.get('table.stickyHeaders');
-
-    if (usingStickyHeaders) {
-      this.$('table').floatThead({
-        position: 'absolute',
-        scrollContainer($table) {
-          return $table.closest('.table-columns');
-        }
-      });
-    }
   },
 
   willDestroyElement() {
@@ -250,16 +231,10 @@ export default Ember.Component.extend({
     @private
   */
   _onRowEnter() {
-    let rowIndex = this.$('tr').index(this.$('tr:hover'));
-    let hasStickyHeaders = this.get('table.stickyHeaders');
-
-    // sticky headers creates a shell table, don't count that row
-    if (hasStickyHeaders) {
-      rowIndex = Math.max(0, rowIndex - 1);
-    }
+    let rowIndex = this.$('tr.table-row').index(this.$('tr:hover'));
 
     this._onRowLeave();
-    this.get('table').$(`tr.table-row:nth-of-type(${rowIndex})`).addClass('hover');
+    this.get('table').$(`tr.table-row:nth-of-type(${rowIndex + 1})`).addClass('hover');
   },
 
   _onRowLeave() {


### PR DESCRIPTION
If sticky headers are enabled, this waits to set them up until the user scrolls instead of setting them up on init.

It avoids edge cases where column heights haven’t full adjusted and fixed table headers are different sizes than the standard headers.

Init of the plugin is done inside of a requestAnimationFrame call to try and ensure scrolling doesn’t suffer.
