### PR TITLE
Only reflow headers on column change.

### DIFF
--- a/addon/components/basic-header.js
+++ b/addon/components/basic-header.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/basic-header';
 
-const { computed, run } = Ember;
+const { computed } = Ember;
 
 export default Ember.Component.extend({
   layout,
@@ -13,13 +13,6 @@ export default Ember.Component.extend({
 
   column: null,
   resizable: computed.readOnly('column.resizable'),
-
-  didReceiveAttrs() {
-    this._super(...arguments);
-
-    let columns = this.get('parentView');
-    run.scheduleOnce('actions', columns, columns.reflowStickyHeaders);
-  },
 
   didRender() {
     this._setColumnWidth();

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -115,8 +115,28 @@ export default Ember.Component.extend({
       }
     });
 
+    let columnLength = this.get('_columnLength');
+    if (columnLength !== uniqueColumns.length) {
+      this.set('_columnLength', uniqueColumns.length);
+      scheduleOnce('afterRender', this, this.reflowStickyHeaders);
+
+      // jscs:disable requireCommentsToIncludeAccess
+      /**
+        TODO: replace floatThead with custom solution.
+        floatThead gets its positioning out of wack on adding columns. This
+        resets the standard column scroll position on column change, which
+        makes things line up properly.
+
+      */
+      scheduleOnce('afterRender', this, () => {
+        this.$('.table-columns').scrollLeft(0);
+      });
+    }
+
     return uniqueColumns.sortBy('index');
   }),
+
+  _columnLength: 0,
 
   /**
     Register a child column with this table columns wrapper.
@@ -127,7 +147,6 @@ export default Ember.Component.extend({
     let columns = this.get('_allColumns');
     column.index = column.index || -1;
     columns.addObject(column);
-    scheduleOnce('afterRender', this, this.reflowStickyHeaders);
   },
 
   /**
@@ -139,7 +158,6 @@ export default Ember.Component.extend({
   unregisterColumn(column) {
     let allColumns = this.get('_allColumns');
     allColumns.removeObject(column);
-    scheduleOnce('afterRender', this, this.reflowStickyHeaders);
   },
 
   didInsertElement() {
@@ -170,11 +188,6 @@ export default Ember.Component.extend({
   didRender() {
     this._super(...arguments);
     this.get('table').didRenderCollection();
-
-    if (!this.get('widthAndPositionSet')) {
-      this.reflowStickyHeaders();
-    }
-
     this._setTableWidthAndPosition();
   },
 

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -50,7 +50,7 @@
   }
 
   .table-columns {
-    overflow-x: scroll;
+    overflow-x: auto;
     height: 500px;
     max-height: 500px;
     position: relative;


### PR DESCRIPTION
Before, we were calling reflow everytime a table cell was added/removed.

This now counts unique columns, and only calls reflow when columns change.

Additionally, there is a bug in floatThead where positioning gets out of whack until you scroll horizontally. To address this, we reset the horizontal table column scroll to 0 on column add/remove.
