### PR TITLE
Fix tables randomly "turning blank" after scrolling

### DIFF
--- a/addon/services/browser.js
+++ b/addon/services/browser.js
@@ -1,0 +1,125 @@
+import Ember from 'ember';
+
+const {
+  Service,
+  computed
+} = Ember;
+
+export default Service.extend({
+  browserInfo: computed(function() {
+    /*!
+     * Browser detection code from Layout-Engine by Matt Stow.
+     * https://github.com/stowball/Layout-Engine
+
+     * Modified to return object rather than creating a global and adding
+     * classes to the html tag.
+    */
+    // jscs:disable disallowMultipleVarDecl, requireObjectDestructuring
+    let html = document.documentElement,
+      style = html.style,
+      vendor = ' vendor-',
+      edge = 'edge',
+      ie = 'ie',
+      khtml = 'khtml',
+      mozilla = 'mozilla',
+      opera = 'opera',
+      webkit = 'webkit',
+      browser = ' browser-',
+      android = 'android',
+      chrome = 'chrome',
+      safari = 'safari',
+      iosSafari = `${safari}-ios`,
+      wiiu = 'wiiu',
+      cssClass = vendor,
+      jsObject;
+    // jscs:enable disallowMultipleVarDecl, requireObjectDestructuring
+
+    // Edge and IE
+    if ('msScrollLimit' in style || 'behavior' in style) {
+      if ('msTextSizeAdjust' in style) {
+        cssClass += edge;
+        jsObject = {
+          vendor: edge
+        };
+      } else {
+        cssClass += ie + vendor + ie;
+        jsObject = {
+          vendor: ie
+        };
+        if ('msImeAlign' in style) {
+          cssClass += '-11';
+          jsObject.version = 11;
+        } else if ('msUserSelect' in style) {
+          cssClass += '-10';
+          jsObject.version = 10;
+        } else if ('fill' in style) {
+          cssClass += '-9';
+          jsObject.version = 9;
+        } else if ('widows' in style) {
+          cssClass += '-8';
+          jsObject.version = 8;
+        } else {
+          cssClass += '-7';
+          jsObject.version = 7;
+        }
+      }
+    }
+    // WebKit
+    else if ('WebkitAppearance' in style) {
+      cssClass += webkit;
+      let ua = navigator.userAgent;
+
+      jsObject = {
+        vendor: webkit
+      };
+
+      if (!!window.chrome || ua.indexOf('OPR') >= 0 || ua.indexOf('wv') >= 0) {
+        cssClass += browser + chrome;
+        jsObject.browser = chrome;
+      } else if ('webkitDashboardRegion' in style) {
+        cssClass += browser + safari;
+        jsObject.browser = safari;
+      } else if ('webkitOverflowScrolling' in style) {
+        cssClass += browser + iosSafari;
+        jsObject.browser = iosSafari;
+      } else if (ua.indexOf('Android') >= 0) {
+        cssClass += browser + android;
+        jsObject.browser = android;
+      } else if (!!window.wiiu) {
+        cssClass += browser + wiiu;
+        jsObject.browser = wiiu;
+      }
+    }
+    // Mozilla
+    else if ('MozAppearance' in style) {
+      cssClass += mozilla;
+      jsObject = {
+        vendor: mozilla
+      };
+    }
+    // Opera
+    else if ('OLink' in style || !!window.opera) {
+      cssClass += opera;
+
+      jsObject = {
+        vendor: opera
+      };
+
+      if ('OMiniFold' in style) {
+        cssClass += '-mini';
+        jsObject.browser = 'mini';
+      }
+    }
+    // KHTML
+    else if ('KhtmlUserInput' in style) {
+      cssClass += khtml;
+      jsObject = {
+        vendor: khtml
+      };
+    } else {
+      return false;
+    }
+
+    return jsObject;
+  })
+});

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -18,8 +18,9 @@
           tagName="tbody"
           itemClassNames=(concat 'table-row ' mergedRowClasses)
           content=table.collapseTableData
+          containerSize=table.containerSize
           defaultHeight=rowHeight
-          bufferSize=0.5
+          bufferSize=1
           alwaysUseDefaultHeight=true
           containerSelector=".table-columns"
           on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
@@ -38,8 +39,9 @@
           tagName="tbody"
           itemClassNames=(concat 'table-row ' mergedRowClasses)
           content=table.content
+          containerSize=table.containerSize
           defaultHeight=rowHeight
-          bufferSize=0.5
+          bufferSize=1
           alwaysUseDefaultHeight=true
           containerSelector=".table-columns"
           as |row|}}

--- a/app/services/browser.js
+++ b/app/services/browser.js
@@ -1,0 +1,1 @@
+export { default } from 'justa-table/services/browser';

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -51,6 +51,7 @@
 
   .table-columns {
     overflow-x: auto;
+    overflow-y: auto !important;
     height: 500px;
     max-height: 500px;
     position: relative;

--- a/tests/unit/services/browser-test.js
+++ b/tests/unit/services/browser-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:browser', 'Unit | Service | browser', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
- adds browser service to check current browser
- fixes cases where tables would calculate dimensions  incorrectly if initially below the viewport, especially on Windows/Chrome
- sets table scroll to `auto` instead of forcing `overflow: scroll`
