### PR TITLE
Adds an additional div that gets bottom padding

### DIFF
--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -1,51 +1,53 @@
 <div class="table-columns">
-  <table class="table">
-    <thead>
-      <tr>
-        {{#each columns as |column|}}
-          {{component column.headerComponent
-            table=table
-            column=column
-            class=column.headerClassNames
-            onColumnWidthChange=(action 'columnWidthChanged')}}
-        {{/each}}
-      </tr>
-    </thead>
+  <div class="scroll-buffer">
+    <table class="table">
+      <thead>
+        <tr>
+          {{#each columns as |column|}}
+            {{component column.headerComponent
+              table=table
+              column=column
+              class=column.headerClassNames
+              onColumnWidthChange=(action 'columnWidthChanged')}}
+          {{/each}}
+        </tr>
+      </thead>
 
-    {{#if table.collapsable}}
-      {{#table-vertical-collection
-        tagName="tbody"
-        itemClassNames=(concat 'table-row ' mergedRowClasses)
-        content=table.collapseTableData
-        defaultHeight=rowHeight
-        bufferSize=0.5
-        alwaysUseDefaultHeight=true
-        containerSelector=".table-columns"
-        on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
+      {{#if table.collapsable}}
+        {{#table-vertical-collection
+          tagName="tbody"
+          itemClassNames=(concat 'table-row ' mergedRowClasses)
+          content=table.collapseTableData
+          defaultHeight=rowHeight
+          bufferSize=0.5
+          alwaysUseDefaultHeight=true
+          containerSelector=".table-columns"
+          on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
 
-        {{#if row.label}}
-          <td colspan={{columns.length}} class="table-cell">
-            {{row.label}}
-          </td>
-        {{else if (or row.isParent (not row.parent.IsCollapsed))}}
+          {{#if row.label}}
+            <td colspan={{columns.length}} class="table-cell">
+              {{row.label}}
+            </td>
+          {{else if (or row.isParent (not row.parent.IsCollapsed))}}
+            {{yield row}}
+          {{/if}}
+
+        {{/table-vertical-collection}}
+      {{else}}
+        {{#vertical-collection
+          tagName="tbody"
+          itemClassNames=(concat 'table-row ' mergedRowClasses)
+          content=table.content
+          defaultHeight=rowHeight
+          bufferSize=0.5
+          alwaysUseDefaultHeight=true
+          containerSelector=".table-columns"
+          as |row|}}
+
           {{yield row}}
-        {{/if}}
 
-      {{/table-vertical-collection}}
-    {{else}}
-      {{#vertical-collection
-        tagName="tbody"
-        itemClassNames=(concat 'table-row ' mergedRowClasses)
-        content=table.content
-        defaultHeight=rowHeight
-        bufferSize=0.5
-        alwaysUseDefaultHeight=true
-        containerSelector=".table-columns"
-        as |row|}}
-
-        {{yield row}}
-
-      {{/vertical-collection}}
-    {{/if}}
-  </table>
+        {{/vertical-collection}}
+      {{/if}}
+    </table>
+  </div>
 </div>

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -37,6 +37,10 @@
     td, td:hover {
       background: rgb(245, 245, 245);
     }
+
+    .scroll-buffer {
+      background: rgb(245, 245, 245);
+    }
   }
 
   .fake-rowspan {

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -67,7 +67,15 @@
     .table-columns {
       overflow-x: hidden;
       -ms-overflow-style: none;
-      margin-right: -14px;
+      margin-right: -15px;
+    }
+
+    /*
+      Unfortunately, this is necessary to fix sizing issues between fixed/non-fixed
+      columns on windows.
+    */
+    .scroll-buffer {
+      padding-bottom: 16px;
     }
 
     .table-columns::-webkit-scrollbar {
@@ -77,7 +85,7 @@
     // end hide scroll indicator
 
     table {
-      width: calc(100% - 14px);
+      width: calc(100% - 15px);
     }
   }
 


### PR DESCRIPTION
Fixes an issue on windows where the fixed columns were 1 horizontal
scrollbar worth too short compared to the non-fixed columns.

This adds additional padding equal to the height of the scrollbar. Does
not impact mac browsers.
