### PR TITLE
Scroll to the top after setting content

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -128,6 +128,23 @@ export default Component.extend({
     return isPresent(hasWindowsString);
   }),
 
+  content: computed({
+    get() {
+      return this.get('_content');
+    },
+    set(key, value) {
+      this.set('_content', value);
+      run.scheduleOnce('afterRender', this, this._scrollToTop);
+      return value;
+    }
+  }),
+
+  _content: null,
+
+  _scrollToTop() {
+    this.$('.table-columns').scrollTop(0, 0);
+  },
+
   /**
     Queues sending 'didRenderTable' action. This is called once the columns
     have rendered data.

--- a/addon/components/table-column.js
+++ b/addon/components/table-column.js
@@ -162,5 +162,6 @@ export default Component.extend({
   */
   _unregisterWithParent(parent) {
     parent.unregisterColumn(this);
+    this.set('_registeredParent', null);
   }
 });

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -157,7 +157,9 @@ export default Ember.Component.extend({
   */
   unregisterColumn(column) {
     let allColumns = this.get('_allColumns');
-    allColumns.removeObject(column);
+    if (allColumns) {
+      allColumns.removeObject(column);
+    }
   },
 
   didInsertElement() {
@@ -167,6 +169,7 @@ export default Ember.Component.extend({
 
   willDestroyElement() {
     this._uninstallStickyHeaders();
+    this.set('_allColumns', null);
 
     this.$().off('mouseenter', 'tr', this._onRowEnter.bind(this));
     this.$().off('mouseleave', 'tr', this._onRowLeave.bind(this));


### PR DESCRIPTION
When table content is completely replaced, ensure scroll is reset.
