### PR TITLE
[WIP] Rework hiding offscreen content, better scrolling, better sticky headers

### DIFF
--- a/addon/components/fixed-table-columns.js
+++ b/addon/components/fixed-table-columns.js
@@ -3,7 +3,8 @@ import layout from '../templates/components/table-columns';
 import TableColumns from './table-columns';
 
 const {
-  assert
+  assert,
+  run
 } = Ember;
 
 export default TableColumns.extend({
@@ -21,14 +22,46 @@ export default TableColumns.extend({
     @private
   */
   _setTableWidthAndPosition() {
-    let tableWidth = this.get('tableWidth');
+    let width = this.get('tableWidth');
+    // height = 500;
     let hasBeenSet = this.get('widthAndPositionSet');
-    if (tableWidth === 0 || hasBeenSet) {
+    if (width === 0 || hasBeenSet) {
       return;
     }
 
-    this.$().css('width', tableWidth);
+    this.$().css({
+      width
+      // height
+    });
     this.set('widthAndPositionSet', true);
+  },
+
+  didInsertElement() {
+    this._super(...arguments);
+    // this.$().bind('wheel', (e) => {
+    //   this.$().css('pointer-events', 'none');
+    //   // this._updateTableScroll(e);
+    //   // run.debounce(this, this._updateTableScroll, e, 50);
+    //   run.debounce(this, this._enablePointerEvents, e, 300);
+    // });
+  },
+
+  _enablePointerEvents() {
+    this.$().css('pointer-events', 'auto');
+  },
+
+  _updateTableScroll(e) {
+    let table = this.get('table').$('.justa-table');
+    let newScrollTop = table.scrollTop() + e.originalEvent.deltaY;
+    let newScrollLeft = table.scrollLeft() + e.originalEvent.deltaX;
+
+    table.scrollTop(newScrollTop);
+    table.scrollLeft(newScrollLeft);
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+    this.$().unbind('wheel');
   },
 
   actions: {

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -255,7 +255,10 @@ export default Component.extend(InViewportMixin, {
   _setupScrollListeners() {
     let table = this.$('.justa-table');
 
-    table.scroll(() => {
+    table.scroll((e) => {
+      let top = e.target.scrollTop;
+      this.$('.fixed-table-columns-wrapper').css('transform', `translateY(-${top}px)`);
+
       // this._setupStickyHeaders();
       // columns.not(e.target).scrollTop(e.target.scrollTop);
       // run.scheduleOnce('sync', this, this._updateVisibleRowIndexes);

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -141,7 +141,7 @@ export default Component.extend(InViewportMixin, {
 
     this.$().height(totalHeight);
     // windows does not respect the height set, so it needs a 2px buffer if horizontal scrollbar
-    this.$('.table-columns').height(shouldAddHeightBuffer ? totalHeight + 2 : totalHeight);
+    // this.$('.table-columns').height(shouldAddHeightBuffer ? totalHeight + 2 : totalHeight);
   },
 
   _hasHorizontalScroll() {
@@ -240,11 +240,11 @@ export default Component.extend(InViewportMixin, {
     @private
   */
   _setupScrollListeners() {
-    let columns = this.$('.table-columns');
+    let columns = this.$();
 
-    columns.scroll((e) => {
+    columns.scroll(() => {
       this._setupStickyHeaders();
-      columns.not(e.target).scrollTop(e.target.scrollTop);
+      // columns.not(e.target).scrollTop(e.target.scrollTop);
       run.scheduleOnce('sync', this, this._updateVisibleRowIndexes);
     });
   },
@@ -292,7 +292,7 @@ export default Component.extend(InViewportMixin, {
   */
   _updateVisibleRowIndexes() {
     window.requestAnimationFrame(() => {
-      let columnDiv = this.$('.standard-table-columns-wrapper .table-columns');
+      let columnDiv = this.$();
       let scrollTop = !columnDiv || columnDiv.length === 0 ? 0 : columnDiv.scrollTop();
       let rowHeight = this.get('rowHeight');
       let visibleRowCount = this.get('visibleRowCount');

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -166,11 +166,13 @@ export default Ember.Component.extend({
   },
 
   didInsertElement() {
+    this._super(...arguments);
     this.$().on('mouseenter', 'tr', this._onRowEnter.bind(this));
     this.$().on('mouseleave', 'tr', this._onRowLeave.bind(this));
   },
 
   willDestroyElement() {
+    this._super(...arguments);
     this._uninstallStickyHeaders();
     this.set('_allColumns', null);
 

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -40,6 +40,9 @@ export default Ember.Component.extend({
   */
   rowGroupDataName: readOnly('table.rowGroupDataName'),
 
+  topRowIndex: readOnly('table.topRowIndex'),
+  bottomRowIndex: readOnly('table.bottomRowIndex'),
+
   init() {
     this._super(...arguments);
     this.classNames.pushObject(`${this.columnType}-table-columns-wrapper`);

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -231,10 +231,10 @@ export default Ember.Component.extend({
 
     let fixedColumnWidth = table.fixedColumnWidth();
     let width = table.$().width() - fixedColumnWidth;
-    let left = fixedColumnWidth;
+    let paddingLeft = fixedColumnWidth;
 
     this.$().css({
-      left
+      paddingLeft
     });
 
     this.$('.table-columns').css({

--- a/addon/templates/components/basic-header.hbs
+++ b/addon/templates/components/basic-header.hbs
@@ -1,4 +1,6 @@
-{{column.headerName}}
-{{#if resizable}}
-  {{column-resize-handle column=column onColumnWidthChange=(action 'onColumnWidthChange')}}
-{{/if}}
+<div class="table-header-wrapper">
+  {{column.headerName}}
+  {{#if resizable}}
+    {{column-resize-handle column=column onColumnWidthChange=(action 'onColumnWidthChange')}}
+  {{/if}}
+</div>

--- a/addon/templates/components/justa-table.hbs
+++ b/addon/templates/components/justa-table.hbs
@@ -1,9 +1,11 @@
-{{#if noContent}}
-  <h2>No Content</h2>
-{{else}}
-  {{yield this}}
-{{/if}}
+<div class="justa-table {{if table.isLoading 'isLoading'}} {{if table.stickyHeaders 'stickyHeaders'}} {{if table.isWindows 'is-windows'}}">
+  {{#if noContent}}
+    <h2>No Content</h2>
+  {{else}}
+    {{yield this}}
+  {{/if}}
 
-{{#if paginate}}
-  {{in-viewport-checker on-enter-viewport=(action 'viewportEntered')}}
-{{/if}}
+  {{#if paginate}}
+    {{in-viewport-checker on-enter-viewport=(action 'viewportEntered')}}
+  {{/if}}
+</div>

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -43,6 +43,7 @@
                   <td colspan={{columns.length}} class="table-cell">
                     {{row.label}}
                   </td>
+                {{!-- TODO: in-range helper  --}}
                 {{else if (or row.isParent (not row.parent.IsCollapsed))}}
                   {{#if (and (gte index topRowIndex) (lte index bottomRowIndex))}}
                     {{yield row}}
@@ -72,7 +73,8 @@
           <tbody>
             {{#each table.content as |row index|}}
               <tr class={{concat 'table-row ' mergedRowClasses}} style={{table.rowHeightStyle}}>
-                {{#if (and (gte index topRowIndex) (lte index bottomRowIndex))}}
+                {{!-- TODO: roll up helper --}}
+                {{#if (lte index bottomRowIndex)}}
                   {{yield row}}
                 {{/if}}
               </tr>

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -14,26 +14,44 @@
       </thead>
 
       {{#if table.collapsable}}
-        {{#table-vertical-collection
-          tagName="tbody"
-          itemClassNames=(concat 'table-row ' mergedRowClasses)
-          content=table.collapseTableData
-          containerSize=table.containerSize
-          defaultHeight=rowHeight
-          bufferSize=1
-          alwaysUseDefaultHeight=true
-          containerSelector=".table-columns"
-          on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
+        {{#if table.hideOffscreenContent}}
+          {{#table-vertical-collection
+            tagName="tbody"
+            itemClassNames=(concat 'table-row ' mergedRowClasses)
+            content=table.collapseTableData
+            containerSize=table.containerSize
+            defaultHeight=rowHeight
+            bufferSize=1
+            alwaysUseDefaultHeight=true
+            containerSelector=".table-columns"
+            on-row-click=(action 'toggleRowCollapse' target=table) as |row|}}
 
-          {{#if row.label}}
-            <td colspan={{columns.length}} class="table-cell">
-              {{row.label}}
-            </td>
-          {{else if (or row.isParent (not row.parent.IsCollapsed))}}
-            {{yield row}}
-          {{/if}}
+            {{#if row.label}}
+              <td colspan={{columns.length}} class="table-cell">
+                {{row.label}}
+              </td>
+            {{else if (or row.isParent (not row.parent.IsCollapsed))}}
+              {{yield row}}
+            {{/if}}
 
-        {{/table-vertical-collection}}
+          {{/table-vertical-collection}}
+        {{else}}
+          <tbody>
+            {{#each table.collapseTableData as |row index|}}
+              <tr class="table-row {{mergedRowClasses}} {{if (eq row.isParent true) 'collapsable'}} {{if (eq row.isCollapsed true) 'is-collapsed' 'is-expanded'}} {{if row.loading 'is-loading'}}" style={{table.rowHeightStyle}} {{action 'toggleRowCollapse' row index target=table}}>
+                {{#if row.label}}
+                  <td colspan={{columns.length}} class="table-cell">
+                    {{row.label}}
+                  </td>
+                {{else if (or row.isParent (not row.parent.IsCollapsed))}}
+                  {{#if (and (gte index topRowIndex) (lte index bottomRowIndex))}}
+                    {{yield row}}
+                  {{/if}}
+                {{/if}}
+              </tr>
+            {{/each}}
+          </tbody>
+        {{/if}}
       {{else}}
         {{#if table.hideOffscreenContent}}
           {{#vertical-collection

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -35,20 +35,32 @@
 
         {{/table-vertical-collection}}
       {{else}}
-        {{#vertical-collection
-          tagName="tbody"
-          itemClassNames=(concat 'table-row ' mergedRowClasses)
-          content=table.content
-          containerSize=table.containerSize
-          defaultHeight=rowHeight
-          bufferSize=1
-          alwaysUseDefaultHeight=true
-          containerSelector=".table-columns"
-          as |row|}}
+        {{#if table.hideOffscreenContent}}
+          {{#vertical-collection
+            tagName="tbody"
+            itemClassNames=(concat 'table-row ' mergedRowClasses)
+            content=table.content
+            containerSize=table.containerSize
+            defaultHeight=rowHeight
+            bufferSize=1
+            alwaysUseDefaultHeight=true
+            containerSelector=".table-columns"
+            as |row|}}
 
-          {{yield row}}
+            {{yield row}}
 
-        {{/vertical-collection}}
+          {{/vertical-collection}}
+        {{else}}
+          <tbody>
+            {{#each table.content as |row index|}}
+              <tr class={{concat 'table-row ' mergedRowClasses}} style={{table.rowHeightStyle}}>
+                {{#if (and (gte index topRowIndex) (lte index bottomRowIndex))}}
+                  {{yield row}}
+                {{/if}}
+              </tr>
+            {{/each}}
+          </tbody>
+        {{/if}}
       {{/if}}
     </table>
   </div>

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -1,7 +1,8 @@
-.justa-table {
+.justa-table-wrapper {
   margin-bottom: 1em;
   border: 1px solid #e5e5e5;
-
+}
+.justa-table {
   table {
     background: #fff;
   }

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -2,6 +2,10 @@
   margin-bottom: 1em;
   border: 1px solid #e5e5e5;
 
+  table {
+    background: #fff;
+  }
+
   th {
     border-right: 1px solid #666;
   }

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -1,9 +1,15 @@
+.justa-table-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
 .justa-table {
   width: 100%;
   height: 500px;
-  position: relative;
-  overflow-y: auto;
-  overflow-x: hidden;
+  // position: relative;
+  // overflow-y: auto;
+  // overflow-x: hidden;
+  overflow: auto;
 
   table {
     border-collapse: collapse;
@@ -47,16 +53,20 @@
   }
 
   .table-columns-wrapper {
-    position: absolute;
-    z-index: 2;
+    // position: absolute;
+    // z-index: 2;
   }
 
   .table-columns {
-    overflow-x: auto;
+    // overflow-x: auto;
     // overflow-y: auto !important;
     // height: 500px;
     // max-height: 500px;
-    position: relative;
+    // position: relative;
+
+    table {
+      width: 100%;
+    }
 
     tr {
       background: white;
@@ -65,23 +75,12 @@
 
   .fixed-table-columns-wrapper {
     z-index: 1;
-
-    // hide the fixed-column scroll indicator
-    .table-columns {
-      overflow-x: hidden;
-      -ms-overflow-style: none;
-      margin-right: -15px;
-    }
-
-    .table-columns::-webkit-scrollbar {
-      display: none;
-      width: 0 !important;
-    }
-    // end hide scroll indicator
-
-    table {
-      width: calc(100% - 15px);
-    }
+    width: 579px;
+    top: 0px;
+    left: 0px;
+    overflow: hidden;
+    position: absolute;
+    transform: translateY(0px);
   }
 
   .is-collapsed {

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -1,6 +1,7 @@
 .justa-table-wrapper {
   position: relative;
   overflow: hidden;
+  width: 100%;
 }
 
 .justa-table {
@@ -55,6 +56,7 @@
   .table-columns-wrapper {
     // position: absolute;
     // z-index: 2;
+    // overflow: hidden;
   }
 
   .table-columns {
@@ -75,12 +77,13 @@
 
   .fixed-table-columns-wrapper {
     z-index: 1;
-    width: 579px;
+    width: 30%;
     top: 0px;
     left: 0px;
     overflow: hidden;
     position: absolute;
     transform: translateY(0px);
+    // padding-bottom: 15px;
   }
 
   .is-collapsed {

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -2,6 +2,7 @@
   width: 100%;
   height: 500px;
   position: relative;
+  overflow-y: auto;
 
   table {
     border-collapse: collapse;
@@ -51,9 +52,9 @@
 
   .table-columns {
     overflow-x: auto;
-    overflow-y: auto !important;
-    height: 500px;
-    max-height: 500px;
+    // overflow-y: auto !important;
+    // height: 500px;
+    // max-height: 500px;
     position: relative;
 
     tr {

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -3,6 +3,7 @@
   height: 500px;
   position: relative;
   overflow-y: auto;
+  overflow-x: hidden;
 
   table {
     border-collapse: collapse;
@@ -107,6 +108,6 @@
   Unfortunately, this is necessary to fix sizing issues between fixed/non-fixed
   columns on windows.
 */
-.is-windows .fixed-table-columns-wrapper .scroll-buffer {
-  padding-bottom: 16px;
-}
+// .is-windows .fixed-table-columns-wrapper .scroll-buffer {
+//   padding-bottom: 16px;
+// }


### PR DESCRIPTION
- [x] replace smoke and mirrors with simpler solution
- [x] use wheel listener to scroll fixed columns instead of double scrollbar
- [ ] make hideOffscreenContent opt in
- [ ] rework sticky headers without plugin
- [ ] double check positioning in all browsers (especially windows)
