### PR TITLE
always yield rows to show headers in collapsable table

### DIFF
--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -31,6 +31,13 @@
             {{#if row.label}}
               <td colspan={{columns.length}} class="table-cell">
                 {{row.label}}
+                <!--
+                  TODO: This is messy, but is necessary to render headers
+                  for rows that are collapsable. NEEDS TO BE FIXED
+                  -->
+                  <div style="display:none;">
+                    {{yield row}}
+                  </div>
               </td>
             {{else if (or row.isParent (not row.parent.IsCollapsed))}}
               {{yield row}}
@@ -44,6 +51,13 @@
                 {{#if row.label}}
                   <td colspan={{columns.length}} class="table-cell">
                     {{row.label}}
+                    <!--
+                      TODO: This is messy, but is necessary to render headers
+                      for rows that are collapsable. NEEDS TO BE FIXED
+                      -->
+                      <div style="display:none;">
+                        {{yield row}}
+                      </div>
                   </td>
                 {{else if (or row.isParent (not row.parent.IsCollapsed))}}
                   {{yield row}}


### PR DESCRIPTION
This fixes a bug when using collapsable tables with the label option. When all rows are collapsed, headers fail to render.

This change needs to be improved on but it at least gets the headers to show.
