### PR TITLE
Skip scrollToTop when opening collapsed rows

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -194,7 +194,7 @@ export default Component.extend(InViewportMixin, {
     set(key, value) {
       this.set('_content', value);
 
-      if (!this.get('isDestroying') && !this.get('isDestroyed')) {
+      if (!this.get('isDestroying') && !this.get('isDestroyed') && !this.get('collapsable')) {
         run.scheduleOnce('afterRender', this, this._scrollToTop);
       }
 


### PR DESCRIPTION
- current behavior is to scroll to the top of the table when opening a row for the first time
- this skips the scrollToTop call if the table is collapsable

I'm not sure if this is the best way to accomplish the result, but I think the behavior is more along what a user would expect.
