### PR TITLE
Fixed 0 width when adding and removing a column on IE

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -147,21 +147,23 @@ export default Component.extend(InViewportMixin, {
     let totalHeight = actualHeight === 0 ? requestedHeight : Math.min(requestedHeight, actualHeight);
     let isWindows = this.get('isWindows');
     let shouldAddHeightBuffer = isWindows && this.get('isIE') && this._hasHorizontalScroll();
-    if (this._hasHorizontalScroll()) {
-      totalHeight = totalHeight + HORIZONTAL_SCROLLBAR_HEIGHT;
-    }
 
-    this.$().height(totalHeight);
-    // windows does not respect the height set, so it needs a 2px buffer if horizontal scrollbar
-    this.$('.table-columns').height(shouldAddHeightBuffer ? totalHeight + 2 : totalHeight);
+    run.next(() => {
+      if (this._hasHorizontalScroll()) {
+        totalHeight = totalHeight + HORIZONTAL_SCROLLBAR_HEIGHT;
+      }
 
-    run.next(() => this.set('containerSize', totalHeight));
+      this.$().height(totalHeight);
+      // windows does not respect the height set, so it needs a 2px buffer if horizontal scrollbar
+      this.$('.table-columns').height(shouldAddHeightBuffer ? totalHeight + 2 : totalHeight);
+
+      this.set('containerSize', totalHeight);
+    });
   },
 
   _hasHorizontalScroll() {
     let tableWidth = this.$('.standard-table-columns-wrapper table').outerWidth();
     let containerWidth = this.$('.standard-table-columns-wrapper .table-columns').outerWidth();
-
     return tableWidth > containerWidth;
   },
 

--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -199,9 +199,9 @@ export default Ember.Component.extend({
   didRender() {
     this._super(...arguments);
     run.next(() => {
+      this._setTableWidthAndPosition();
       this.get('table').didRenderCollection();
     });
-    this._setTableWidthAndPosition();
   },
 
   didReceiveAttrs() {

--- a/tests/integration/components/justa-table-test.js
+++ b/tests/integration/components/justa-table-test.js
@@ -366,11 +366,12 @@ test('recalculates fixed column width', function(assert) {
 
     {{/justa-table}}
   `);
-
   return wait().then(() => {
     assert.equal(this.$('.fixed-table-columns-wrapper').width(), 152);
     this.set('showState', true);
-    assert.equal(this.$('.fixed-table-columns-wrapper').width(), 254);
+    return wait().then(() => {
+      assert.equal(this.$('.fixed-table-columns-wrapper').width(), 254);
+    });
   });
 });
 


### PR DESCRIPTION
When a column is added then removed and added again, will set width to 0, collapsing all columns,  to solve this added on `Ember.next()` any width and height calculation.
