### PR TITLE
Ensure equal header height in next run loop

### DIFF
--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -106,7 +106,7 @@ export default Component.extend(InViewportMixin, {
     @public
   */
   ensureEqualHeaderHeight() {
-    run.scheduleOnce('afterRender', this, this._ensureEqualHeaderHeight);
+    run.next(this, this._ensureEqualHeaderHeight);
   },
 
   /**


### PR DESCRIPTION
This change fix an issue with the rendering of the headers of the table of some scenarios where the function "_ensureEqualHeaderHeight" is called before the rendering is completely done
