### PR TITLE
Add default blueprint

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/justa-table/index.js
+++ b/blueprints/justa-table/index.js
@@ -1,0 +1,17 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'install justa-table into a project',
+
+  normalizeEntityName: function() {}
+
+  // locals: function(options) {
+  //   // Return custom template variables here.
+  //   return {
+  //     foo: options.entity.options.foo
+  //   };
+  // }
+
+  // afterInstall: function(options) {
+  //   // Perform extra work here.
+  // }
+};

--- a/blueprints/justa-table/index.js
+++ b/blueprints/justa-table/index.js
@@ -2,7 +2,11 @@
 module.exports = {
   description: 'install justa-table into a project',
 
-  normalizeEntityName: function() {}
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('jquery.floatThead', '^1.3.2');
+  }
 
   // locals: function(options) {
   //   // Return custom template variables here.

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+
 module.exports = {
   name: 'justa-table',
+
   included: function(app) {
     this._super.included(app);
 
-    app.import('bower_components/jquery.floatThead/dist/jquery.floatThead.js');
+    app.import(path.join(app.bowerDirectory, 'jquery.floatThead/dist/jquery.floatThead.js'));
   }
 };


### PR DESCRIPTION
I've been attempting to `npm link`  `justa-table` into another app from a local fork, but the only way to have the installation process triggered when doing this is for `ember g justa-table` to be run within the consuming project. 

I generated a default blueprint for enabling that -- which should also come in handy in the future.

Note: This also addresses #101.
