### PR TITLE
Implement faster unique columns function

### DIFF
--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/table-columns';
+import uniqBy from 'justa-table/utils/unique-by';
 
 const {
   A,
@@ -111,16 +112,9 @@ export default Ember.Component.extend({
     @public
   */
   columns: computed('_allColumns.[]', function columns() {
-    let uniqueColumns = new A();
-    this.get('_allColumns').forEach((column) => {
-      let headerName = column.get('headerName');
-      let existingHeaderNames = new A(uniqueColumns.mapBy('headerName'));
-      if (!existingHeaderNames.contains(headerName)) {
-        uniqueColumns.push(column);
-      }
-    });
+    const uniqueColumns = uniqBy(this.get('_allColumns') || [], 'headerName');
+    const columnLength = this.get('_columnLength');
 
-    let columnLength = this.get('_columnLength');
     if (columnLength !== uniqueColumns.length) {
       this.set('_columnLength', uniqueColumns.length);
       this.set('widthAndPositionSet', false);

--- a/addon/utils/unique-by.js
+++ b/addon/utils/unique-by.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+const {
+  A,
+  isArray,
+  get,
+  guidFor
+} = Ember;
+
+/**
+ * Helper for a list of objects that computes unique objects by a 'propertyKey'
+ */
+function uniqueBy(items, propertyKey) {
+  const uniques = A();
+  const seen = Object.create(null);
+
+  if (isArray(items)) {
+    items.forEach(item => {
+      const guid = guidFor(get(item, propertyKey));
+
+      if (!(guid in seen)) {
+        seen[guid] = true;
+        uniques.push(item);
+      }
+    });
+  }
+
+  return uniques;
+}
+
+export default uniqueBy;

--- a/tests/unit/utils/unique-columns-test.js
+++ b/tests/unit/utils/unique-columns-test.js
@@ -1,0 +1,48 @@
+import uniqBy from 'justa-table/utils/unique-by';
+import { module, test } from 'qunit';
+
+const ITEMS = [
+  { city: 'New York', country: 'United States' },
+  { city: 'Boston', country: 'United States' },
+  { city: 'London', country: 'England' },
+  { city: 'Paris', country: 'France' },
+  { city: 'Moscow', country: 'Russia' },
+  { city: 'St. Petersburg', country: 'Russia' },
+  { city: 'St. Petersburg', country: 'United States' },
+  { city: 'Rome', country: 'Italy' }
+];
+
+const UNIQUE_BY_CITY = [
+  ITEMS[0],
+  ITEMS[1],
+  ITEMS[2],
+  ITEMS[3],
+  ITEMS[4],
+  ITEMS[5],
+  ITEMS[7]
+];
+
+const UNIQUE_BY_COUNTRY = [
+  ITEMS[0],
+  ITEMS[2],
+  ITEMS[3],
+  ITEMS[4],
+  ITEMS[7]
+];
+
+let actual, expected;
+
+module('Unit | Utility | unique-by');
+
+// Replace this with your real tests.
+test('finding the unique object in a list according to a given property', function(assert) {
+  expected = UNIQUE_BY_CITY;
+  actual = uniqBy(ITEMS, 'city');
+
+  assert.deepEqual(actual, expected);
+
+  expected = UNIQUE_BY_COUNTRY;
+  actual = uniqBy(ITEMS, 'country');
+
+  assert.deepEqual(actual, expected);
+});


### PR DESCRIPTION
This partially addresses #82 by speeding up the way unique columns are currently being computed. 

[As noted](https://github.com/cball/justa-table/issues/82#issuecomment-243124707), there may be better strategies altogether that we can look out for in the future... but also maybe not.
