### PR TITLE
A11y Enhancements

### DIFF
--- a/addon/components/basic-header.js
+++ b/addon/components/basic-header.js
@@ -6,6 +6,7 @@ const { computed } = Ember;
 export default Ember.Component.extend({
   layout,
   tagName: 'th',
+  attributeBindings: ['scope'],
   classNameBindings: ['alignCenter:center', 'alignRight:right', 'textWrap'],
   alignCenter: computed.equal('column.align', 'center'),
   alignRight: computed.equal('column.align', 'right'),
@@ -13,6 +14,13 @@ export default Ember.Component.extend({
 
   column: null,
   resizable: computed.readOnly('column.resizable'),
+
+  /**
+   * Accessability attribute that, for screen readers, unambiguously establishes
+   * the cells that the header comprised by this <th> element relates to.
+   * @see: http://webaim.org/techniques/tables/data#scope
+   */
+  scope: 'col',
 
   didRender() {
     let table = this.get('table');

--- a/addon/components/justa-table.js
+++ b/addon/components/justa-table.js
@@ -63,6 +63,25 @@ export default Component.extend(InViewportMixin, {
   rowClasses: null,
 
   /**
+   * A caption for the table. If supplied, this will be inserted into
+   * a <caption> tag as the first-child node of the <table>
+   * @public
+   */
+  caption: null,
+
+  /**
+   * "left", "center", or "right" text alignment for the caption
+   * @public
+   */
+  captionAlignment: null,
+
+  /**
+   * Support hiding the caption from view, but still rendering it
+   * for accessibility.
+   */
+  hideCaption: false,
+
+  /**
     If content is empty.
     @public
   */

--- a/addon/components/table-caption.js
+++ b/addon/components/table-caption.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import layout from '../templates/components/table-caption';
+
+const { Component, computed } = Ember;
+
+export default Component.extend({
+  layout,
+  tagName: 'caption',
+  classNameBindings: ['alignmentClass', 'hideFromView:visually-hidden'],
+
+  caption: null,
+  alignment: null,
+  hiddenFromView: false,
+
+  alignmentClass: computed('alignment', {
+    get() {
+      const alignment = (this.get('alignment') || 'center').toLowerCase();
+
+      return {
+        left: 'align-left',
+        center: 'align-center',
+        right: 'align-right'
+      }[alignment];
+    }
+  })
+});

--- a/addon/templates/components/table-caption.hbs
+++ b/addon/templates/components/table-caption.hbs
@@ -1,0 +1,1 @@
+{{caption}}{{yield}}

--- a/addon/templates/components/table-columns.hbs
+++ b/addon/templates/components/table-columns.hbs
@@ -1,6 +1,9 @@
 <div class="table-columns">
   <div class="scroll-buffer">
     <table class="table">
+      {{#if table.caption}}
+        {{table-caption caption=table.caption alignment=table.captionAlignment hideFromView=table.hideCaption}}
+      {{/if}}
       <thead>
         <tr>
           {{#each columns as |column|}}

--- a/app/components/table-caption.js
+++ b/app/components/table-caption.js
@@ -1,0 +1,1 @@
+export { default } from 'justa-table/components/table-caption';

--- a/app/styles/justa-table/_justa-table-appearance.scss
+++ b/app/styles/justa-table/_justa-table-appearance.scss
@@ -2,6 +2,21 @@
   margin-bottom: 1em;
   border: 1px solid #e5e5e5;
 
+  caption {
+    text-align: center;
+    border-bottom: 0.1625em solid #DDDDDD;  // TODO: Determine whether or not this is actually an appropriate concern
+  }
+
+  // @see: http://webaim.org/techniques/css/invisiblecontent/#absolutepositioning
+  caption.visually-hidden {
+    position: absolute;
+    top: auto;
+    left: -10000px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
   th {
     border-right: 1px solid #666;
   }

--- a/app/styles/justa-table/_justa-table-structure.scss
+++ b/app/styles/justa-table/_justa-table-structure.scss
@@ -4,9 +4,15 @@
   position: relative;
 
   table {
+    width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     border-spacing: 0;
   }
+
+  caption.align-left { text-align: left; }
+  caption.align-center { text-align: center; }
+  caption.align-right { text-align: right; }
 
   tr {
     height: 36px;
@@ -39,10 +45,6 @@
     white-space: normal;
   }
 
-  table {
-    width: 100%;
-    table-layout: fixed;
-  }
 
   .table-columns-wrapper {
     position: absolute;

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/pods/components/basic-table/component.js
+++ b/tests/dummy/app/pods/components/basic-table/component.js
@@ -4,6 +4,8 @@ import layout from './template';
 export default Ember.Component.extend({
   layout,
   dynamicColumns: null,
+  content: null,
+  hideCaption: false,
 
   init() {
     this._super(...arguments);
@@ -47,6 +49,10 @@ export default Ember.Component.extend({
       });
 
       this.set('dynamicColumns', newColumns);
+    },
+
+    toggleCaption() {
+      this.toggleProperty('hideCaption');
     }
   }
 });

--- a/tests/dummy/app/pods/components/basic-table/template.hbs
+++ b/tests/dummy/app/pods/components/basic-table/template.hbs
@@ -1,9 +1,10 @@
 <a href="#" class="btn btn-default" {{action 'removeSomeRows'}}>- Remove some rows</a>
 <a href="#" class="btn btn-default" {{action 'insertSomeColumns'}}>+ Insert some columns</a>
 <a href="#" class="btn btn-default" {{action 'removeAColumn'}}>- Remove a dynamic column</a>
+<a href="#" class="btn btn-default" {{action 'toggleCaption'}}>- Toggle Caption Visibility</a>
 <br>
 
-{{#justa-table content=content as |table|}}
+{{#justa-table content=content caption='Basic Table Example' hideCaption=hideCaption as |table|}}
   {{#table-columns table=table as |row|}}
 
     {{table-column

--- a/tests/dummy/app/pods/examples/fixed-column-table/template.hbs
+++ b/tests/dummy/app/pods/examples/fixed-column-table/template.hbs
@@ -1,6 +1,6 @@
 <a href="#" {{action 'removeSomeRows'}}>Remove some rows</a>
 
-{{#justa-table content=model as |table|}}
+{{#justa-table content=model caption='Fixed Columns Example' captionAlignment='left' as |table|}}
   {{#fixed-table-columns table=table as |row|}}
     {{table-column
       row=row

--- a/tests/dummy/app/pods/examples/group-by-name/template.hbs
+++ b/tests/dummy/app/pods/examples/group-by-name/template.hbs
@@ -1,4 +1,4 @@
-{{#justa-table content=model as |table|}}
+{{#justa-table content=model caption='Grouped by Name' as |table|}}
   {{#table-columns table=table as |row|}}
 
     {{table-column

--- a/tests/dummy/app/pods/examples/hide-offscreen/template.hbs
+++ b/tests/dummy/app/pods/examples/hide-offscreen/template.hbs
@@ -1,6 +1,7 @@
 {{#justa-table
   content=content
   hideOffscreenContent=true
+  caption='Hide Offscreen Rows Example'
   as |table|}}
 
   {{#table-columns table=table as |row|}}

--- a/tests/dummy/app/pods/examples/infinite-loader-table/template.hbs
+++ b/tests/dummy/app/pods/examples/infinite-loader-table/template.hbs
@@ -1,4 +1,4 @@
-{{#justa-table content=model paginate=true on-load-more-rows=(action 'loadMoreUsers') as |table|}}
+{{#justa-table content=model paginate=true on-load-more-rows=(action 'loadMoreUsers') caption='Infinitely loading rows example' as |table|}}
   {{#table-columns table=table as |row|}}
 
     {{table-column

--- a/tests/dummy/app/pods/examples/resizable-columns-table/template.hbs
+++ b/tests/dummy/app/pods/examples/resizable-columns-table/template.hbs
@@ -1,4 +1,4 @@
-{{#justa-table content=model as |table|}}
+{{#justa-table content=model caption='Resizeable Columns Example' as |table|}}
   {{#table-columns table=table as |row|}}
     {{table-column
       row=row

--- a/tests/dummy/app/pods/examples/sticky-headers/template.hbs
+++ b/tests/dummy/app/pods/examples/sticky-headers/template.hbs
@@ -1,4 +1,4 @@
-{{#justa-table content=model stickyHeaders=true as |table|}}
+{{#justa-table content=model stickyHeaders=true caption='Sticky Headers Example' as |table|}}
   {{#fixed-table-columns table=table as |row|}}
     {{table-column
       row=row

--- a/tests/integration/components/justa-table-test.js
+++ b/tests/integration/components/justa-table-test.js
@@ -17,17 +17,20 @@ function getRow(context, rowObject) {
   return context.$(`tbody tr:nth-of-type(${row})`);
 }
 
-test('it renders content', function(assert) {
+test('rendering content', function(assert) {
   let content = [
     { name: 'Fred' },
     { name: 'Wilma' },
     { name: undefined }
   ];
 
+  const caption = 'The Flinstones';
+
   this.set('content', content);
+  this.set('caption', caption);
 
   this.render(hbs`
-    {{#justa-table content=content as |table|}}
+    {{#justa-table content=content caption=caption as |table|}}
       {{#table-columns table=table as |row|}}
         {{table-column
           row=row
@@ -39,6 +42,7 @@ test('it renders content', function(assert) {
   `);
 
   return wait().then(() => {
+    assert.equal(this.$('table').children()[0].textContent.trim(), caption, `The first child of the <table> is a caption with the provided content of ${caption}`);
     assert.equal(this.$('th').text().trim(), 'foo', 'our column was named foo');
     assert.equal(this.$('tr').length, 4, 'should have 2 rows and a header row');
     assert.equal(getCell(this, { row: 1, cell: 1 }).text().trim(), 'Fred', 'first cell should be Fred');

--- a/tests/integration/components/table-caption-test.js
+++ b/tests/integration/components/table-caption-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('table-caption', 'Integration | Component | table caption', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{table-caption}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#table-caption}}
+      template block text
+    {{/table-caption}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
After digging into the project for a bit, I've come up with a few ideas for improving the accessibility of our elements to users with assistive devices.

For one, we can allow users to specify a [table caption](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption) -- as well as its alignment -- at the root level, and then place/align a `<caption>` element just after the `<table>` element that we render.

We can also allow columns to have a `scope` attribute. [This article provides a good description](http://webaim.org/techniques/tables/data#scope), but essentially, when table structures start to get a bit complex, having a `scope` attribute on `th` elements gives screen readers an unambiguous declaration of how that `th` is supposed to fit in to the puzzle.
