### PR TITLE
Remove deprecated Ember.K

### DIFF
--- a/addon/components/table-vertical-collection.js
+++ b/addon/components/table-vertical-collection.js
@@ -1,8 +1,7 @@
-import Ember from 'ember';
 import layout from '../templates/components/table-vertical-collection';
 import VerticalCollection from 'smoke-and-mirrors/components/vertical-collection';
 
 export default VerticalCollection.extend({
   layout,
-  'on-row-click': Ember.K
+  'on-row-click'() {}
 });


### PR DESCRIPTION
This PR builds on #113. After reading up on the [deprecation RFC for Ember.K](https://github.com/emberjs/rfcs/pull/178), #113 seems like a pretty straightforward change, but I also wanted to remove the unused `import Ember from 'ember'` statement that was being used for `K`.