### PR TITLE
add logic to blueprint to conditionally install `ember-get-helper`

### DIFF
--- a/blueprints/justa-table/index.js
+++ b/blueprints/justa-table/index.js
@@ -1,21 +1,27 @@
 /*jshint node:true*/
+
+var VersionChecker = require('ember-cli-version-checker');
+
 module.exports = {
   description: 'install justa-table into a project',
 
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('jquery.floatThead', '^1.3.2');
+    const promises = [
+      this.addBowerPackageToProject('jquery.floatThead', '^1.3.2')
+    ];
+
+    if (this._shouldInstallGetHelper()) {
+      promises.push(this.addPackageToProject('ember-get-helper', '1.1.0'));
+    }
+
+    return Promise.all(promises);
+  },
+
+  _shouldInstallGetHelper() {
+    const checker = new VersionChecker(this);
+
+    return checker.for('ember', 'bower').satisfies('< 2.0.0');
   }
-
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
-
-  // afterInstall: function(options) {
-  //   // Perform extra work here.
-  // }
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.0",
     "ember-cli-sass": "^5.1.0",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-in-viewport": "2.0.8",
     "ember-truth-helpers": "^1.0.0",
     "smoke-and-mirrors": "cball/smoke-and-mirrors#2c265a4"


### PR DESCRIPTION
Closes #83. 

After getting a better understanding of what this was going for, I think a good solution would be to simply check the installing project's `ember` version [inside of our blueprint](https://github.com/cball/justa-table/pull/115/files#diff-8cada36713f881b8561e39e34ebe4dc8R25), and then only add `ember-get-helper` to the project if necessary. As such, I also [removed it from our own dependencies](https://github.com/cball/justa-table/pull/115/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L45).