### PR TITLE
Use `classNameBindings` instead of writing into `classNames`

### DIFF
--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -16,6 +16,8 @@ const DEFAULT_ROW_HEIGHT = 37;
 export default Ember.Component.extend({
   layout,
   classNames: ['table-columns-wrapper'],
+  classNameBindings: ['columnTypeClass'],
+
   columnType: 'standard',
 
   /**
@@ -48,12 +50,11 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
 
-    this.classNames.push(`${this.columnType}-table-columns-wrapper`);
     this._allColumns = A();
   },
 
   /**
-    If the intiial width/position has been set after rendering.
+    If the initial width/position has been set after rendering.
     @public
   */
   widthAndPositionSet: false,
@@ -73,6 +74,16 @@ export default Ember.Component.extend({
       let style = getComputedStyle(column.element);
       return parseInt(style.borderRightWidth, 10) + parseInt(style.borderLeftWidth, 10);
     });
+  }),
+
+  /**
+   * A dynamic class name for this component's top-level columns
+   * wrapper -- based upon the `columnType`
+   */
+  columnTypeClass: computed('columnType', {
+    get() {
+      return `${this.get('columnType')}-table-columns-wrapper`;
+    }
   }),
 
   /**


### PR DESCRIPTION
Partially closes #116 

Directly muting `classNames` is slated to be [disallowed in the next version of Ember](https://github.com/emberjs/ember.js/pull/14389), and thus the one instance where we were [doing this in our `table-columns` component] seems to be the culprit for our [current CI failures](https://circleci.com/gh/cball/justa-table/119) (testing against `ember-beta` and `ember-canary`).

This PR updates the component so that instead of pushing into `classNames` inside of `init`, we just compute the `columnType`-dependent class as a `classNameBinding`. 